### PR TITLE
Add workflow to release helm-charts to gh-pages and ghcr.io

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,70 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/helm-release.yml'
+      - 'charts/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@v2.8.1
+        with:
+          version: v1.13.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.10.3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR and sign
+        # when filling gaps with previously released charts, cr would create
+        # nothing in .cr-release-packages/, and the original globbing character
+        # would be preserved, causing a non-zero exit. Set nullglob to fix this
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/helm-charts |& tee .digest
+            file="${pkg##*/}"       # extracts file name from full directory path
+            name="${file%-*}"       # extracts chart name from filename
+            digest="$(awk -F "[, ]+" '/Digest/{print $NF}' < .digest)"
+            cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/helm-charts/"${name}"@"${digest}"
+          done
+        env:
+          COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
This uses the same release workflow as

- https://github.com/philips-labs/helm-charts (I'm a maintainer here)
- https://github.com/sigstore/helm-charts (I'm a contributor here)