### PR TITLE
Remove the need for hostpath on oidc provider

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
@@ -94,9 +94,7 @@ spec:
             driver: "csi.spiffe.io"
             readOnly: true
         - name: spire-oidc-sockets
-          hostPath:
-            path: /run/spire/oidc-sockets
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: spire-oidc-config
           configMap:
             name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}


### PR DESCRIPTION
The hostpath isn't needed. This patch removes the extra mount and changes it to an emptyDir.

Fixes https://github.com/spiffe/helm-charts/issues/24