### PR TITLE
Only check for version bump if PR targets release branch

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --debug ${{ github.base_ref != 'main' && '--check-version-increment=false' || '' }} \
+          ct lint --debug ${{ github.base_ref != 'release' && '--check-version-increment=false' || '' }} \
             --target-branch ${{ github.base_ref }}
 
     outputs:

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -3,7 +3,7 @@ name: Release Helm Charts
 on:
   push:
     branches:
-      - main
+      - release
     paths:
       - '.github/workflows/helm-release.yml'
       - 'charts/**'


### PR DESCRIPTION
Resolves #30 

See https://github.com/spiffe/helm-charts/actions/runs/4236147935/jobs/7360619030#step:7:2 when PR is targeted at other branch then main.