### PR TITLE
Make spire agent work standalone and parallel installable

### DIFF
--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -10,6 +10,7 @@ A Helm chart to install the SPIRE agent.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` | Override where the agent looks for the socket. Only used if socketMacroName is unchanged. |
 | bundleConfigMap | string | `"spire-bundle"` |  |
 | clusterName | string | `"example-cluster"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/spire/charts/spire-agent/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-agent/templates/_helpers.tpl
@@ -72,3 +72,11 @@ Create the name of the service account to use
 {{- printf "%s/%s" .image.registry .image.repository -}}
 {{- end -}}
 {{- end }}
+
+{{- define "spire-agent.agent-socket-path" -}}
+{{ include .Values.socketMacroName . }}
+{{- end }}
+
+{{- define "spire-agent.agent-socket-path-standalone" -}}
+{{- print .Values.agentSocketPath }}
+{{- end }}

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
       log_level = {{ .Values.logLevel | quote }}
       server_address = "{{ .Release.Name }}-server"
       server_port = {{ .Values.server.port | quote }}
-      socket_path = {{ include "spire.agent-socket-path" . | quote }}
+      socket_path = {{ include "spire-agent.agent-socket-path" . | quote }}
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = {{ .Values.trustDomain | quote }}
     }

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
               mountPath: /run/spire/bundle
               readOnly: true
             - name: spire-agent-socket-dir
-              mountPath: {{ include "spire.agent-socket-path" . | dir }}
+              mountPath: {{ include "spire-agent.agent-socket-path" . | dir }}
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens
@@ -98,5 +98,5 @@ spec:
                 audience: spire-server
         - name: spire-agent-socket-dir
           hostPath:
-            path: {{ include "spire.agent-socket-path" . | dir }}
+            path: {{ include "spire-agent.agent-socket-path" . | dir }}
             type: DirectoryOrCreate

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -84,3 +84,9 @@ telemetry:
   prometheus:
     enabled: false
     port: 9988
+
+# -- Override where the agent looks for the socket. Only used if socketMacroName is unchanged.
+agentSocketPath: /run/spire/agent-sockets/spire-agent.sock
+
+# @ignored
+socketMacroName: spire-agent.agent-socket-path-standalone

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# @ignored
+global: {}
+
 image:
   # registry: gcr.io
   # repository: spiffe-io/spire-agent

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -25,6 +25,9 @@ spire-agent:
   clusterName: *clusterName
   trustDomain: *trustDomain
 
+  # @ignored
+  socketMacroName: "spire.agent-socket-path"
+
 spiffe-csi-driver:
   # @ignored
   socketMacroName: "spire.agent-socket-path"


### PR DESCRIPTION
This patch enables the agent chart to be usable by itself. It also enables multiple instances of it to be installed on the same cluster at once.

Partially fixes https://github.com/spiffe/helm-charts/issues/63