### PR TITLE
Allow to configure a priorityClassName for Daemonsets

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -26,6 +26,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| priorityClassName | string | `""` | Priority class assigned to daemonset pods |
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         # This is the container which runs the SPIFFE CSI driver.
         - name: {{ .Chart.Name }}

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -63,3 +63,6 @@ nodeDriverRegistrar:
     # limits:
     #   cpu: 100m
     #   memory: 64Mi
+
+# -- Priority class assigned to daemonset pods
+priorityClassName: ""

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -24,6 +24,7 @@ A Helm chart to install the SPIRE agent.
 | nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| priorityClassName | string | `""` | Priority class assigned to daemonset pods |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | server.port | int | `8081` |  |

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
       serviceAccountName: {{ include "spire-agent.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       initContainers:
         - name: init
           # This is a small image with wait-for-it, choose whatever image

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -84,3 +84,6 @@ telemetry:
   prometheus:
     enabled: false
     port: 9988
+
+# -- Priority class assigned to daemonset pods
+priorityClassName: ""


### PR DESCRIPTION
This enables to define a higher priority for daemonsets so that on
existing nodes there will be created room for the daemonset to run.

E.g. a karpenter autoscaled cluster will create new nodes for spire deployments and
replicasets etc. But for the existing nodes in some occasions there is not enough room to run the daemonset.
Passing a priorityClassName of `system-node-critical` e.g. evicts other pods with a lower class from
that node to make room for the daemonset.
