### PR TITLE
Add support for oidc-discovery-provider ingress

### DIFF
--- a/.github/tests/spire-oidc-insecure/pre-install.sh
+++ b/.github/tests/spire-oidc-insecure/pre-install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+helm install ingress-nginx ingress-nginx --version 4.5.2 --repo https://kubernetes.github.io/ingress-nginx -n "$VALUES" --set controller.extraArgs.enable-ssl-passthrough=
+kubectl wait --namespace ingress-nginx   --for=condition=ready pod   --selector=app.kubernetes.io/component=controller -n "$VALUES"

--- a/.github/tests/spire-oidc-insecure/pre-install.sh
+++ b/.github/tests/spire-oidc-insecure/pre-install.sh
@@ -1,3 +1,4 @@
-#!/bin/bash
-helm install ingress-nginx ingress-nginx --version 4.5.2 --repo https://kubernetes.github.io/ingress-nginx -n "$VALUES" --set controller.extraArgs.enable-ssl-passthrough=
-kubectl wait --namespace ingress-nginx   --for=condition=ready pod   --selector=app.kubernetes.io/component=controller -n "$VALUES"
+#!/usr/bin/env bash
+
+helm install ingress-nginx ingress-nginx --version 4.5.2 --repo https://kubernetes.github.io/ingress-nginx -n "$scenario" --set controller.extraArgs.enable-ssl-passthrough=
+kubectl wait --namespace ingress-nginx   --for=condition=ready pod   --selector=app.kubernetes.io/component=controller -n "$scenario"

--- a/.github/tests/spire-oidc-insecure/values.yaml
+++ b/.github/tests/spire-oidc-insecure/values.yaml
@@ -6,7 +6,16 @@ spiffe-oidc-discovery-provider:
 
   config:
     domains:
-      - oidc-discovery.example.org
+      - ingress-nginx-controller
 
     acme:
       tosAccepted: false
+
+  ingress:
+    enabled: true
+    className: "nginx"
+    hosts:
+    - host: ingress-nginx-controller
+      paths:
+        - path: /
+          pathType: Prefix

--- a/.github/tests/spire-oidc-insecure/values.yaml
+++ b/.github/tests/spire-oidc-insecure/values.yaml
@@ -13,7 +13,7 @@ spiffe-oidc-discovery-provider:
 
   ingress:
     enabled: true
-    className: "nginx"
+    className: nginx
     hosts:
     - host: ingress-nginx-controller
       paths:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -34,6 +34,13 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | image.repository | string | `"spiffe/oidc-discovery-provider"` |  |
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| ingress.tls | list | `[]` |  |
 | insecureScheme.enabled | bool | `false` |  |
 | insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | insecureScheme.nginx.image.registry | string | `"docker.io"` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -37,7 +37,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].host | string | `"oidc-discovery.example.org"` |  |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/ingress.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
   labels:
     {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/ingress.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "spiffe-oidc-discovery-provider.fullname" . }}
+{{- $port := .Values.service.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -29,4 +29,12 @@ spec:
       args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- if and .Values.ingress.enabled .Values.ingress.test.enabled }}
+    - name: wget-ingress
+      image: busybox
+      command: ['wget']
+      args: ['{{ index .Values.config.domains 0 }}/.well-known/openid-configuration']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- end }}
   restartPolicy: Never

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -29,11 +29,11 @@ spec:
       args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-    {{- if and .Values.ingress.enabled .Values.ingress.test.enabled }}
+    {{- if .Values.ingress.enabled }}
     - name: wget-ingress
       image: busybox
       command: ['wget']
-      args: ['{{ index .Values.config.domains 0 }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ index .Values.config.domains 0 }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     {{- end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -144,6 +144,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts:
     - host: oidc-discovery.example.org
       paths:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -112,7 +112,7 @@ tolerations: []
 
 affinity: {}
 
-trustDomain: "example.org"
+trustDomain: example.org
 
 telemetry:
   prometheus:
@@ -145,11 +145,11 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: oidc-discovery.example.org
       paths:
         - path: /
           pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
-  #      - chart-example.local
+  #      - oidc-discovery.example.org

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -137,3 +137,19 @@ telemetry:
         # limits:
         #   cpu: 100m
         #   memory: 64Mi
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
This patch enables exposing the oidc server out with an ingress along with tests to ensure it works.

Resolves #56 