### PR TITLE
Add extra initContainers, containers, volumes to agent and server

### DIFF
--- a/.github/tests/extras/values.yaml
+++ b/.github/tests/extras/values.yaml
@@ -1,0 +1,61 @@
+spire-agent:
+  initContainers:
+  - name: extra-init
+    image: busybox
+    command:
+    - sh
+    - -xec
+    - |
+      echo 'hi there' > /extra/file
+    volumeMounts:
+    - name: extra
+      mountPath: /extra
+  extraContainers:
+  - name: extra
+    image: busybox
+    command:
+    - sh
+    - -xec
+    - |
+      [ -f /extra/file ]
+      while true; do sleep 1000; done
+    volumeMounts:
+    - name: extra
+      mountPath: /extra
+  extraVolumeMounts:
+  - name: extra
+    mountPath: /extra
+  extraVolumes:
+  - name: extra
+    emptyDir: {}
+
+spire-server:
+  initContainers:
+  - name: extra-init
+    image: busybox
+    command:
+    - sh
+    - -xec
+    - |
+      echo 'hi there' > /extra/file
+    volumeMounts:
+    - name: extra
+      mountPath: /extra
+  extraContainers:
+  - name: extra
+    image: busybox
+    command:
+    - sh
+    - -xec
+    - |
+      [ -f /extra/file ]
+      while true; do sleep 1000; done
+    volumeMounts:
+    - name: extra
+      mountPath: /extra
+  extraVolumeMounts:
+  - name: extra
+    mountPath: /extra
+  extraVolumes:
+  - name: extra
+    emptyDir: {}

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -12,6 +12,9 @@ A Helm chart to install the SPIRE agent.
 |-----|------|---------|-------------|
 | bundleConfigMap | string | `"spire-bundle"` |  |
 | clusterName | string | `"example-cluster"` |  |
+| extraContainers | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | healthChecks.port | int | `9980` | override the host port used for health checking |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -19,6 +22,7 @@ A Helm chart to install the SPIRE agent.
 | image.repository | string | `"spiffe/spire-agent"` |  |
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| initContainers | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
           args: ["-t", "30", "-h", "{{ .Release.Name }}-server", "-p", {{ .Values.server.port | quote }}]
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
+        {{- if gt (len .Values.initContainers) 0 }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ template "spire-agent.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.image) }}
@@ -67,6 +70,9 @@ spec:
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens
+            {{- if gt (len .Values.extraVolumeMounts) 0 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /live
@@ -81,6 +87,9 @@ spec:
             periodSeconds: 60
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if gt (len .Values.extraContainers) 0 }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -103,3 +112,6 @@ spec:
           hostPath:
             path: {{ include "spire.agent-socket-path" . | dir }}
             type: DirectoryOrCreate
+        {{- if gt (len .Values.extraVolumes) 0 }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -87,3 +87,9 @@ telemetry:
 
 # -- Priority class assigned to daemonset pods
 priorityClassName: ""
+
+extraVolumes: []
+extraVolumeMounts: []
+extraContainers: []
+
+initContainers: []

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -42,12 +42,16 @@ A Helm chart to install the SPIRE server.
 | dataStorage.enabled | bool | `true` |  |
 | dataStorage.size | string | `"1Gi"` |  |
 | dataStorage.storageClass | string | `nil` |  |
+| extraContainers | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"spiffe/spire-server"` |  |
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| initContainers | list | `[]` |  |
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -32,6 +32,10 @@ spec:
       shareProcessNamespace: true
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if gt (len .Values.initContainers) 0 }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -84,6 +88,9 @@ spec:
               mountPath: /run/spire/upstream_ca
               readOnly: false
             {{ end }}
+            {{- if gt (len .Values.extraVolumeMounts) 0 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
         {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
         - name: spire-controller-manager
           securityContext:
@@ -121,6 +128,9 @@ spec:
               subPath: controller-manager-config.yaml
               readOnly: true
         {{- end }}
+        {{- if gt (len .Values.extraContainers) 0 }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -152,6 +162,9 @@ spec:
         - name: controller-manager-config
           configMap:
             name: {{ include "spire-controller-manager.fullname" . }}
+        {{- end }}
+        {{- if gt (len .Values.extraVolumes) 0 }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
   volumeClaimTemplates:
     {{- if eq (.Values.dataStorage.enabled | toString) "true" }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -163,3 +163,9 @@ controllerManager:
 telemetry:
   prometheus:
     enabled: false
+
+extraVolumes: []
+extraVolumeMounts: []
+extraContainers: []
+
+initContainers: []


### PR DESCRIPTION
With plugin support, agents and servers need more customization. This patch enables initContainers, extraContainers, extraVolumes and extraVolumeMounts to be added to those services.

Implements: https://github.com/spiffe/helm-charts/issues/52