### PR TITLE
Add arm64 support to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Unless otherwise noted in an application chart README, the following dependencie
 
 | Dependency | Supported Versions |
 |:-----------|:-------------------|
-| SPIRE      | `1.4.x`, `1.5.x`   |
+| SPIRE      | `1.5.x`, `1.6.x`   |
 | Helm       | `3.x`              |
 
 For Kubernetes we will officially try to support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions).

--- a/charts/spire/charts/spiffe-csi-driver/Chart.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/Chart.yaml
@@ -3,4 +3,4 @@ name: spiffe-csi-driver
 description: A Helm chart to install the SPIFFE CSI driver.
 type: application
 version: 0.1.0
-appVersion: "0.2.1"
+appVersion: "0.2.3"

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -2,9 +2,12 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
 
 A Helm chart to install the SPIFFE CSI driver.
+
+> **Note**: The recommended version is `0.2.3` to support arm64 nodes. If running with any
+> prior version to `0.2.3` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
 
 ## Values
 
@@ -23,7 +26,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` |  |
 | nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
 | nodeDriverRegistrar.resources | object | `{}` |  |
-| nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Priority class assigned to daemonset pods |

--- a/charts/spire/charts/spiffe-csi-driver/README.md.gotmpl
+++ b/charts/spire/charts/spiffe-csi-driver/README.md.gotmpl
@@ -10,6 +10,9 @@
 
 {{ template "chart.homepageLine" . }}
 
+> **Note**: The recommended version is `0.2.3` to support arm64 nodes. If running with any
+> prior version to `0.2.3` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -43,8 +43,7 @@ securityContext:
   #   drop:
   #   - ALL
 
-nodeSelector:
-  kubernetes.io/arch: amd64
+nodeSelector: {}
 
 nodeDriverRegistrar:
   image:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
@@ -3,4 +3,4 @@ name: spiffe-oidc-discovery-provider
 description: A Helm chart to install the SPIFFE OIDC discovery provider.
 type: application
 version: 0.1.0
-appVersion: "1.5.4"
+appVersion: "1.6.0"

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -2,9 +2,13 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 A Helm chart to install the SPIFFE OIDC discovery provider.
+
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
 
 ## Values
 
@@ -36,7 +40,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
 | insecureScheme.nginx.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
-| nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md.gotmpl
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md.gotmpl
@@ -10,6 +10,10 @@
 
 {{ template "chart.homepageLine" . }}
 
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -102,8 +102,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
-nodeSelector:
-  kubernetes.io/arch: amd64
+nodeSelector: {}
 
 tolerations: []
 

--- a/charts/spire/charts/spire-agent/Chart.yaml
+++ b/charts/spire/charts/spire-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: spire-agent
 description: A Helm chart to install the SPIRE agent.
 type: application
 version: 0.1.0
-appVersion: "1.5.4"
+appVersion: "1.6.0"

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -2,9 +2,13 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE agent.
+
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
 
 ## Values
 
@@ -21,7 +25,7 @@ A Helm chart to install the SPIRE agent.
 | imagePullSecrets | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
-| nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Priority class assigned to daemonset pods |

--- a/charts/spire/charts/spire-agent/README.md.gotmpl
+++ b/charts/spire/charts/spire-agent/README.md.gotmpl
@@ -10,6 +10,10 @@
 
 {{ template "chart.homepageLine" . }}
 
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -49,8 +49,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-nodeSelector:
-  kubernetes.io/arch: amd64
+nodeSelector: {}
 
 logLevel: info
 clusterName: example-cluster

--- a/charts/spire/charts/spire-server/Chart.yaml
+++ b/charts/spire/charts/spire-server/Chart.yaml
@@ -3,4 +3,4 @@ name: spire-server
 description: A Helm chart to install the SPIRE server.
 type: application
 version: 0.1.0
-appVersion: "1.5.4"
+appVersion: "1.6.0"

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -2,9 +2,16 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE server.
+
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+>
+> The recommended spire-controller-manager version is `0.2.2` to support arm64 nodes. If running with any
+> prior version to `0.2.2` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
 
 ## Values
 
@@ -32,7 +39,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controllerManager.image.registry | string | `"ghcr.io"` |  |
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` |  |
-| controllerManager.image.version | string | `"0.2.1"` |  |
+| controllerManager.image.version | string | `"0.2.2"` |  |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
 | controllerManager.service.annotations | object | `{}` |  |
@@ -51,7 +58,7 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
-| nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` | SPIRE server currently runs with a sqlite database. Scaling to multiple instances will not work until we use an external database. |

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -10,6 +10,13 @@
 
 {{ template "chart.homepageLine" . }}
 
+> **Note**: Minimum Spire version is `1.5.3`.
+> The recommended version is `1.6.0` to support arm64 nodes. If running with any
+> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+>
+> The recommended spire-controller-manager version is `0.2.2` to support arm64 nodes. If running with any
+> prior version to `0.2.2` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -64,8 +64,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-nodeSelector:
-  kubernetes.io/arch: amd64
+nodeSelector: {}
 
 tolerations: []
 
@@ -114,7 +113,7 @@ controllerManager:
     repository: spiffe/spire-controller-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    version: "0.2.1"
+    version: "0.2.2"
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
- Bump spire-server image to 1.6.0 (arm64 support)
- Bump spire-agent image to 1.6.0 (arm64 support)
- Bump spiffe-oidc-discovery-provider image to 1.6.0 (arm64 support)
- Bump spiffe-csi-driver image to 0.2.3 (arm64 support)

See here a list of all my PRs that enabled the arm64 support in the different spire images.

## wait-for-it initContainer

- [x] https://github.com/wolfi-dev/os/pull/243

## spiffe-csi-driver

- [x] https://github.com/spiffe/spiffe-csi/pull/66
- [x] https://github.com/spiffe/spiffe-csi/pull/67
- [x] https://github.com/spiffe/spiffe-csi/pull/68
- [x] https://github.com/spiffe/spiffe-csi/pull/69
- [x] https://github.com/spiffe/spiffe-csi/pull/70
- [x] https://github.com/spiffe/spiffe-csi/pull/71
- [x] https://github.com/spiffe/spiffe-csi/pull/72
- [x] https://github.com/spiffe/spiffe-csi/pull/73

## spire

- [x] https://github.com/spiffe/spire/pull/3580
- [x] https://github.com/spiffe/spire/pull/3633
- [x] https://github.com/spiffe/spire/pull/3635
- [x] https://github.com/spiffe/spire/pull/3652
- [x] https://github.com/spiffe/spire/pull/3656
- [x] https://github.com/spiffe/spire/pull/3678
- [x] https://github.com/spiffe/spire/pull/3679
- [x] https://github.com/spiffe/spire/pull/3607
- [x] https://github.com/spiffe/spire/pull/3706
- [x] https://github.com/spiffe/spire/pull/3707
- [x] https://github.com/spiffe/spire/pull/3766

## spire-controller-manager

- [x] https://github.com/spiffe/spire-controller-manager/pull/58
- [x] https://github.com/spiffe/spire-controller-manager/pull/57
- [x] https://github.com/spiffe/spire-controller-manager/pull/56
- [x] https://github.com/spiffe/spire-controller-manager/pull/53
- [x] https://github.com/spiffe/spire-controller-manager/pull/51

This feels like a huge achievement.
