### PR TITLE
Add k8s 1.26.0 (Kind) to the test matrix

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -110,6 +110,7 @@ jobs:
         # Kubernetes, but can go back farther as long as we don't need heroics
         # to pull it off (i.e. kubectl version juggling).
         k8s:
+          - v1.26.0
           - v1.25.3
           - v1.24.7
           - v1.23.13


### PR DESCRIPTION
Question to maintainers:

Should we keep 1.21 in the test matrix for now, or shall we drop that from the matrix? E.g. limit the tests to max 5 versions.

Officially we only support the last 3 k8s releases as stated in our README.md.

Currently our chart is perfectly compatible with `1.21`.

Personally I think we can leave `1.21` around until we build features that are incompatible with `1.21`.

See https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0 for more details.