### PR TITLE
Make sure all configmap changes rollout

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $configSum := (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,6 +16,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ $configSum }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $configSum := (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) }}
+{{- $configSum2 := (include (print $.Template.BasePath "/controller-manager-configmap.yaml") . | sha256sum) }}
 {{- $fullname := include "spire-server.fullname" . }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -18,6 +19,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ $configSum }}
+        checksum/config2: {{ $configSum2 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
When a change happens to a configmap, kubernetes does not automatically restart any pods that make use of it. This is confusing to users because they think they have made a change, only for the workload to ignore it until the user manually deletes the pods. This change follows the standard helm workaround of annotating the pods with a checksum of the configmaps so that a configmap change becomes visible as a pod change to kubernetes causing it to redeploy the affected workloads properly and automatically during a helm upgrade.

Fixes: https://github.com/spiffe/helm-charts/issues/69