### PR TITLE
Add a flag to configure the Kubernetes NodeAttestor

### DIFF
--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -62,8 +62,8 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
-| nodeAttestor.k8s.enabled | bool | `true` |  |
-| nodeAttestor.k8s.rbac.create | bool | `true` |  |
+| nodeAttestor.k8s.psat.enabled | bool | `true` |  |
+| nodeAttestor.k8s.psat.rbac.create | bool | `true` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -62,8 +62,8 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
-| nodeAttestor.k8s.psat.enabled | bool | `true` |  |
-| nodeAttestor.k8s.psat.rbac.create | bool | `true` |  |
+| nodeAttestor.k8sPsat.enabled | bool | `true` |  |
+| nodeAttestor.k8sPsat.rbac.create | bool | `true` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -62,6 +62,8 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
+| nodeAttestor.k8s.enabled | bool | `true` |  |
+| nodeAttestor.k8s.rbac.create | bool | `true` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
 
       {{- with .Values.nodeAttestor.k8sPsat }}
       {{- if eq (.enabled | toString) "true" }}
-      NodeAttestor "k8sPsat" {
+      NodeAttestor "k8s_psat" {
         plugin_data {
           clusters = {
             {{ $server.Values.clusterName | quote }} = {

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -36,9 +36,9 @@ data:
         }
       }
 
-      {{- with .Values.nodeAttestor.k8s.psat }}
+      {{- with .Values.nodeAttestor.k8sPsat }}
       {{- if eq (.enabled | toString) "true" }}
-      NodeAttestor "k8s_psat" {
+      NodeAttestor "k8sPsat" {
         plugin_data {
           clusters = {
             {{ $server.Values.clusterName | quote }} = {

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ $release := .Release }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,15 +36,19 @@ data:
         }
       }
 
+      {{- with .Values.nodeAttestor.k8s }}
+      {{- if eq (.enabled | toString) "true" }}
       NodeAttestor "k8s_psat" {
         plugin_data {
           clusters = {
             {{ .Values.clusterName | quote }} = {
-              service_account_allow_list = ["{{ .Release.Namespace }}:{{ .Release.Name }}-agent"]
+              service_account_allow_list = ["{{ $release.Namespace }}:{{ $release.Name }}-agent"]
             }
           }
         }
       }
+      {{- end }}
+      {{- end }}
 
       KeyManager "disk" {
         plugin_data {

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ $dot := . }}
+{{ $server := . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,13 +36,13 @@ data:
         }
       }
 
-      {{- with .Values.nodeAttestor.k8s }}
+      {{- with .Values.nodeAttestor.k8s.psat }}
       {{- if eq (.enabled | toString) "true" }}
       NodeAttestor "k8s_psat" {
         plugin_data {
           clusters = {
-            {{ $dot.Values.clusterName | quote }} = {
-              service_account_allow_list = ["{{ $dot.Release.Namespace }}:{{ $dot.Release.Name }}-agent"]
+            {{ $server.Values.clusterName | quote }} = {
+              service_account_allow_list = ["{{ $server.Release.Namespace }}:{{ $server.Release.Name }}-agent"]
             }
           }
         }
@@ -84,7 +84,7 @@ data:
           issuer_name = {{ .issuer_name | quote }}
           issuer_kind = {{ .issuer_kind | quote }}
           issuer_group = {{ .issuer_group | quote }}
-          namespace = {{ default $dot.Release.Namespace .namespace | quote }}
+          namespace = {{ default $server.Release.Namespace .namespace | quote }}
           {{- if ne .kube_config_file "" }}
           kube_config_file = {{ .kube_config_file | quote }}
           {{- end }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -84,7 +84,7 @@ data:
           issuer_name = {{ .issuer_name | quote }}
           issuer_kind = {{ .issuer_kind | quote }}
           issuer_group = {{ .issuer_group | quote }}
-          namespace = {{ default $server.Release.Namespace .namespace | quote }}
+          namespace = {{ default $root.Release.Namespace .namespace | quote }}
           {{- if ne .kube_config_file "" }}
           kube_config_file = {{ .kube_config_file | quote }}
           {{- end }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ $namespace := .Release.Namespace }}
+{{ $dot := . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -41,8 +41,8 @@ data:
       NodeAttestor "k8s_psat" {
         plugin_data {
           clusters = {
-            {{ .Values.clusterName | quote }} = {
-              service_account_allow_list = ["{{ $namespace }}:{{ $release.Name }}-agent"]
+            {{ $dot.Values.clusterName | quote }} = {
+              service_account_allow_list = ["{{ $dot.Release.Namespace }}:{{ $dot.Release.Name }}-agent"]
             }
           }
         }
@@ -84,7 +84,7 @@ data:
           issuer_name = {{ .issuer_name | quote }}
           issuer_kind = {{ .issuer_kind | quote }}
           issuer_group = {{ .issuer_group | quote }}
-          namespace = {{ default $namespace .namespace | quote }}
+          namespace = {{ default $dot.Release.Namespace .namespace | quote }}
           {{- if ne .kube_config_file "" }}
           kube_config_file = {{ .kube_config_file | quote }}
           {{- end }}

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
-{{- if and .Values.nodeAttestor.k8sPsat.enabled .Values.nodeAttestor.k8sPsat.rbac.create }}
+{{- if and .Values.nodeAttestor.k8sPsat.enabled }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API
 # and to be able to push certificate bundles to a configmap

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
-{{- if and .Values.nodeAttestor.k8s.enabled .Values.nodeAttestor.k8s.rbac.create }}
+{{- if and .Values.nodeAttestor.k8s.enabled .Values.nodeAttestor.k8s.psat.rbac.create }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API
 # and to be able to push certificate bundles to a configmap

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
-{{- if and .Values.nodeAttestor.k8s.enabled .Values.nodeAttestor.k8s.psat.rbac.create }}
+{{- if and .Values.nodeAttestor.k8s.psat.enabled .Values.nodeAttestor.k8s.psat.rbac.create }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API
 # and to be able to push certificate bundles to a configmap

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -32,13 +32,15 @@ roleRef:
   kind: Role
   name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+
+{{- if and .Values.nodeAttestor.k8s.enabled .Values.nodeAttestor.k8s.rbac.create }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API
 # and to be able to push certificate bundles to a configmap
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
 rules:
     # allow TokenReview requests (to verify service account tokens for PSAT
     # attestation)
@@ -59,13 +61,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
-{{- if and .Values.nodeAttestor.k8s.psat.enabled .Values.nodeAttestor.k8s.psat.rbac.create }}
+{{- if and .Values.nodeAttestor.k8sPsat.enabled .Values.nodeAttestor.k8sPsat.rbac.create }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API
 # and to be able to push certificate bundles to a configmap

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -40,7 +40,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}
 rules:
     # allow TokenReview requests (to verify service account tokens for PSAT
     # attestation)
@@ -61,7 +61,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -80,6 +80,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Namespace }}-{{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -91,10 +91,6 @@ ca_subject:
   organization: Example
   common_name: example.org
 
-nodeAttestor:
-  k8sPsat:
-    enabled: true
-
 upstreamAuthority:
   disk:
     enabled: false
@@ -184,4 +180,5 @@ initContainers: []
 
 nodeAttestor:
   k8sPsat:
+    enabled: true
     serviceAccountAllowList: []

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -94,8 +94,6 @@ ca_subject:
 nodeAttestor:
   k8sPsat:
     enabled: true
-    rbac:
-      create: true
 
 upstreamAuthority:
   disk:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -93,9 +93,10 @@ ca_subject:
 
 nodeAttestor:
   k8s:
-    enabled: true
-    rbac:
-      create: true
+    psat:
+      enabled: true
+      rbac:
+        create: true
 
 upstreamAuthority:
   disk:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -92,11 +92,10 @@ ca_subject:
   common_name: example.org
 
 nodeAttestor:
-  k8s:
-    psat:
-      enabled: true
-      rbac:
-        create: true
+  k8sPsat:
+    enabled: true
+    rbac:
+      create: true
 
 upstreamAuthority:
   disk:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -91,6 +91,12 @@ ca_subject:
   organization: Example
   common_name: example.org
 
+nodeAttestor:
+  k8s:
+    enabled: true
+    rbac:
+      create: true
+
 upstreamAuthority:
   disk:
     enabled: false


### PR DESCRIPTION
If deploying with alternate NodeAttestors you may want to disable the Kubernetes one. Also a small bug with using a non unique name with cluster wide resources ClusterRole/ClusterRoleBinding is fixed.