### PR TITLE
Test that it is possible to lock down security of pods

### DIFF
--- a/.github/tests/lockdown/deps-values.yaml
+++ b/.github/tests/lockdown/deps-values.yaml
@@ -1,0 +1,54 @@
+global:
+  telemetry:
+    prometheus:
+      enabled: true
+
+spiffe-csi-driver:
+  enabled: false
+
+spire-agent:
+  enabled: false
+
+spiffe-oidc-discovery-provider:
+  enabled: true
+  insecureScheme:
+    enabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
+
+spire-server:
+  nodeAttestor:
+    k8sPsat:
+      serviceAccountAllowList: ["lockdown:spire-agent"]
+  notifier:
+    k8sbundle:
+      namespace: lockdown
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
+  controllerManager:
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault

--- a/.github/tests/lockdown/pre-install.sh
+++ b/.github/tests/lockdown/pre-install.sh
@@ -2,3 +2,4 @@
 kubectl label namespace "$scenario" pod-security.kubernetes.io/enforce=privileged
 kubectl create namespace "${scenario}-deps"
 kubectl label namespace "${scenario}-deps" pod-security.kubernetes.io/enforce=restricted
+helm install -n "${scenario}-deps" spire -f "${TEST_DIR}"/deps-values.yaml

--- a/.github/tests/lockdown/pre-install.sh
+++ b/.github/tests/lockdown/pre-install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+kubectl label namespace "$scenario" pod-security.kubernetes.io/enforce=privileged
+kubectl create namespace "${scenario}-deps"
+kubectl label namespace "${scenario}-deps" pod-security.kubernetes.io/enforce=restricted

--- a/.github/tests/lockdown/values.yaml
+++ b/.github/tests/lockdown/values.yaml
@@ -1,0 +1,20 @@
+global:
+  telemetry:
+    prometheus:
+      enabled: true
+
+spiffe-csi-driver:
+  enabled: true
+
+spire-agent:
+  enabled: true
+  serviceAccount:
+    name: spire-agent
+  server:
+    address: spire-server.lockdown-deps
+
+spiffe-oidc-discovery-provider:
+  enabled: false
+
+spire-server:
+  enabled: false

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -66,7 +66,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ .Release.Namespace}}-{{ include "spire-server.fullname" . }}
 rules:
   - apiGroups: [authentication.k8s.io]
     resources: [tokenreviews]
@@ -85,13 +85,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ .Release.Namespace}}-{{ include "spire-server.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ .Release.Namespace}}-{{ include "spire-server.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
This patch tests that it is possible to run the chart using the Kubernetes Pod Security Standards to secure the
namespaces along with testing restricted mode on pods that support it.