### PR TITLE
Add post-install scripts to all tests to capture failure details in GitHub workflow summary

### DIFF
--- a/.github/tests/common.sh
+++ b/.github/tests/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+get_namespace_details () {
+cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+### Namespace $1
+
+#### Events
+
+\`\`\`shell
+$(kubectl --request-timeout=30s get events --output wide --namespace "$1")
+\`\`\`
+
+#### Pods
+
+\`\`\`shell
+$(kubectl --request-timeout=30s describe pods --namespace "$1")
+\`\`\`
+
+#### Logs
+
+\`\`\`shell
+$(kubectl get pods -o name -n "$1" | while read -r line; do echo logs for "${line}"; kubectl logs -n "$1" "${line}" --all-containers=true --ignore-errors=true; done)
+\`\`\`
+
+EOF
+}
+
+k_wait () {
+  kubectl wait --for condition=available --timeout 30s --namespace "$1" "$2" "$3" | tail -n 1
+}
+
+k_rollout_status () {
+  kubectl rollout status --watch --timeout 30s --namespace "$1" "$2" "$3" | tail -n 1
+}
+
+get_spire_release_name () {
+  helm ls -A | grep '^spire' | awk '{print $1}'
+}
+
+print_spire_workload_status () {
+  local ns1
+  local ns2
+
+  ns1="$1"
+  ns2="${2:-$1}"
+
+  release_name="$(get_spire_release_name)"
+
+  cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+### Spire
+
+| Namespace | Workload                                       | Status |
+| --------- | ---------------------------------------------- | ------ |
+| ${ns1}    | ${release_name}-server                         | <pre>$(k_rollout_status "${ns1}" statefulset "${release_name}-server")</pre> |
+| ${ns2}    | ${release_name}-spiffe-csi-driver              | <pre>$(k_rollout_status "${ns2}" daemonset "${release_name}-spiffe-csi-driver")</pre> |
+| ${ns2}    | ${release_name}-agent                          | <pre>$(k_rollout_status "${ns2}" daemonset "${release_name}-agent")</pre> |
+| ${ns1}    | ${release_name}-spiffe-oidc-discovery-provider | <pre>$(k_rollout_status "${ns1}" deployments.apps "${release_name}-spiffe-oidc-discovery-provider")</pre> |
+
+EOF
+}
+
+print_helm_releases () {
+  cat <<EOF >>"$GITHUB_STEP_SUMMARY"
+### Releases
+
+$(helm ls -A | sed 's/\t/ | /g' | sed 's/^/| /' | sed 's/$/ |/' | sed '/^| NAME.*/a| - | - | - | - | - | - | - |')
+
+EOF
+}

--- a/.github/tests/extras/post-install.sh
+++ b/.github/tests/extras/post-install.sh
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
 if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/federation-bundle-endpoint/post-install.sh
+++ b/.github/tests/federation-bundle-endpoint/post-install.sh
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
 if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/namespace-override/post-install.sh
+++ b/.github/tests/namespace-override/post-install.sh
@@ -2,60 +2,18 @@
 
 set -x
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "${SCRIPT}")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
-k_wait () {
-  kubectl wait --for condition=available --timeout 30s --namespace "$1" "$2" "$3" | tail -n 1
-}
+# shellcheck source=/dev/null
+source "${SCRIPTPATH}/../common.sh"
 
-k_rollout_status () {
-  kubectl rollout status --watch --timeout 30s --namespace "$1" "$2" "$3" | tail -n 1
-}
-
-RELEASE=$(helm ls --no-headers -n "${scenario}" | awk '{print $1}' | grep 'spire-[^-]*$')
-
-cat <<EOF >>"$GITHUB_STEP_SUMMARY"
-### release
-| release |
-| ------- |
-| $RELEASE |
-
-### spire
-| workload | Status |
-| -------- | ------ |
-| spire-server | <pre>$(k_rollout_status spire-server statefulset "${RELEASE}-server")</pre> |
-| spire-spiffe-csi-driver | <pre>$(k_rollout_status spire-system daemonset "${RELEASE}-spiffe-csi-driver")</pre> |
-| spire-agent | <pre>$(k_rollout_status spire-system daemonset "${RELEASE}-agent")</pre> |
-| spire-spiffe-oidc-discovery-provider | <pre>$(k_wait spire-server deployments.apps "${RELEASE}-spiffe-oidc-discovery-provider")</pre> |
-EOF
+print_helm_releases
+print_spire_workload_status spire-server spire-system
 
 if [[ "$1" -ne 0 ]]; then
-  echo
-  echo '```'
-  echo '==> Events of namespace spire-server'
-  echo '........................................................................................................................'
-  echo '>>> kubectl --request-timeout=30s get events --output wide --namespace spire-server'
-  kubectl --request-timeout=30s get events --output wide --namespace spire-server
-  echo '........................................................................................................................'
-  echo '<== Events of namespace spire-server'
-  echo '........................................................................................................................'
-  echo '>>> kubectl --request-timeout=30s describe pods --namespace spire-server'
-  kubectl --request-timeout=30s describe pods --namespace spire-server
-  echo '========================================================================================================================'
-  echo '==> Events of namespace spire-system'
-  echo '........................................................................................................................'
-  echo '>>> kubectl --request-timeout=30s get events --output wide --namespace spire-system'
-  kubectl --request-timeout=30s get events --output wide --namespace spire-system
-  echo '........................................................................................................................'
-  echo '<== Events of namespace spire-system'
-  echo '........................................................................................................................'
-  echo '>>> kubectl --request-timeout=30s describe pods --namespace spire-system'
-  kubectl --request-timeout=30s describe pods --namespace spire-system
-  echo '========================================================================================================================'
-  kubectl get pods -o name -n spire-server | while read -r line; do echo logs for "${line}"; kubectl logs -n spire-server "${line}"--all-containers=true --ignore-errors=true; done
-  kubectl get pods -o name -n spire-system | while read -r line; do echo logs for "${line}"; kubectl logs -n spire-system "${line}" --all-containers=true --ignore-errors=true; done
-  echo '========================================================================================================================'
-  echo '```'
-fi | cat >> "$GITHUB_STEP_SUMMARY"
+  get_namespace_details spire-server
+  get_namespace_details spire-systen
+fi
+

--- a/.github/tests/no-spire-controller-manager/post-install.sh
+++ b/.github/tests/no-spire-controller-manager/post-install.sh
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
 if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/production-example/install.sh
+++ b/.github/tests/production-example/install.sh
@@ -2,8 +2,8 @@
 
 set -xe
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 
 helm install \
   --namespace spire-server \

--- a/.github/tests/prometheus/post-install.sh
+++ b/.github/tests/prometheus/post-install.sh
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
 if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/prometheus/pre-install.sh
+++ b/.github/tests/prometheus/pre-install.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "${SCRIPT}")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
-helm install kube-prometheus-stack kube-prometheus-stack --version "${VERSION_KUBE_PROMETHEUS_STACK}" --repo "${HELM_REPO_KUBE_PROMETHEUS_STACK}" -n "${scenario}" --wait
+helm install kube-prometheus-stack kube-prometheus-stack \
+  --version "${VERSION_KUBE_PROMETHEUS_STACK}" \
+  --repo "${HELM_REPO_KUBE_PROMETHEUS_STACK}" \
+  -n "${scenario}" \
+  --wait

--- a/.github/tests/spire-oidc-insecure/post-install.sh
+++ b/.github/tests/spire-oidc-insecure/post-install.sh
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
 if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/spire-oidc-insecure/pre-install.sh
+++ b/.github/tests/spire-oidc-insecure/pre-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "${SCRIPT}")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
 helm install ingress-nginx ingress-nginx --version "${VERSION_INGRESS_NGINX}" --repo "${HELM_REPO_INGRESS_NGINX}" -n "$scenario" --set controller.extraArgs.enable-ssl-passthrough=

--- a/.github/tests/upstream-authority-cert-manager/post-install.sh
+++ b/.github/tests/upstream-authority-cert-manager/post-install.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-SCRIPT="$(readlink -f "$0")"
+SCRIPT=$(readlink -f "$0")
 SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
-if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+if [ "$1" != '0' ]; then
+  get_namespace_details "${scenario}"
 fi

--- a/.github/tests/upstream-authority-cert-manager/pre-install.sh
+++ b/.github/tests/upstream-authority-cert-manager/pre-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "${SCRIPT}")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
 helm install cert-manager cert-manager --namespace cert-manager --create-namespace --version "$VERSION_CERT_MANAGER" --set installCRDs=true --repo "$HELM_REPO_CERT_MANAGER" --wait

--- a/.github/tests/upstream-authority-disk/post-install.sh
+++ b/.github/tests/upstream-authority-disk/post-install.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-SCRIPT="$(readlink -f "$0")"
+SCRIPT=$(readlink -f "$0")
 SCRIPTPATH="$(dirname "${SCRIPT}")"
 scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 
@@ -10,9 +10,8 @@ scenario="${scenario:-$(basename "${SCRIPTPATH}")}"
 source "${SCRIPTPATH}/../common.sh"
 
 print_helm_releases
-print_spire_workload_status spire-server spire-system
+print_spire_workload_status "${scenario}"
 
-if [[ "$1" -ne 0 ]]; then
-  get_namespace_details spire-server
-  get_namespace_details spire-system
+if [ "$1" != '0' ]; then
+  get_namespace_details "${scenario}"
 fi

--- a/.github/workflows/scripts/update-versions.sh
+++ b/.github/workflows/scripts/update-versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "${SCRIPT}")
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
 
 CHARTJSON="${SCRIPTPATH}/../../tests/charts.json"
 


### PR DESCRIPTION
See https://github.com/spiffe/helm-charts/actions/runs/4808535068

for the result at the summary page.

The checks fail because I didn't update chart docs as intended, that commit bumping the chart version has been removed from this branch once, I saw it nicely executed the workflow.

Please note to merge #242 first. This PR will squash on top of that and therefore doesn't need another rebase, merge.