### PR TITLE
Make spire agent server address configurable

### DIFF
--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -35,6 +35,7 @@ A Helm chart to install the SPIRE agent.
 | priorityClassName | string | `""` | Priority class assigned to daemonset pods |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| server.address | string | `""` |  |
 | server.port | int | `8081` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/spire/charts/spire-agent/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-agent/templates/_helpers.tpl
@@ -72,3 +72,11 @@ Create the name of the service account to use
 {{- printf "%s/%s" .image.registry .image.repository -}}
 {{- end -}}
 {{- end }}
+
+{{- define "spire-agent.server-address" }}
+{{- if .Values.server.address }}
+{{- .Values.server.address }}
+{{- else }}
+{{ .Release.Name }}-server
+{{- end }}
+{{- end }}

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     agent {
       data_dir = "/run/spire"
       log_level = {{ .Values.logLevel | quote }}
-      server_address = "{{ .Release.Name }}-server"
+      server_address = {{ include "spire-agent.server-address" . | trim | quote }}
       server_port = {{ .Values.server.port | quote }}
       socket_path = {{ include "spire.agent-socket-path" . | quote }}
       trust_bundle_path = "/run/spire/bundle/bundle.crt"

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
           # from https://github.com/vishnubob/wait-for-it
           image: {{ template "spire-agent.image" .Values.waitForIt }}
           imagePullPolicy: {{ .Values.waitForIt.image.pullPolicy }}
-          args: ["-t", "30", "-h", "{{ .Release.Name }}-server", "-p", {{ .Values.server.port | quote }}]
+          args: ["-t", "30", "-h", "{{ include "spire-agent.server-address" . | trim }}", "-p", {{ .Values.server.port | quote }}]
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
         {{- if gt (len .Values.initContainers) 0 }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -58,6 +58,7 @@ trustDomain: example.org
 bundleConfigMap: spire-bundle
 
 server:
+  address: ""
   port: 8081
 
 healthChecks:


### PR DESCRIPTION
If your server is not in the same namespace or cluster as the agent, you need a config option to specify where it is.