### PR TITLE
Make server service account allow list configurable

### DIFF
--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -62,6 +62,7 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
+| nodeAttestor.k8sPsat.serviceAccountsAllowed | list | `[]` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -62,7 +62,7 @@ A Helm chart to install the SPIRE server.
 | jwtIssuer | string | `"oidc-discovery.example.org"` |  |
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
-| nodeAttestor.k8sPsat.serviceAccountsAllowed | list | `[]` |  |
+| nodeAttestor.k8sPsat.serviceAccountAllowList | list | `[]` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -94,8 +94,8 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "spire-server.serviceAccountAllowedList" }}
-{{- if ne (len .Values.nodeAttestor.k8sPsat.serviceAccountsAllowed) 0 }}
-{{- .Values.nodeAttestor.k8sPsat.serviceAccountsAllowed | toJson }}
+{{- if ne (len .Values.nodeAttestor.k8sPsat.serviceAccountAllowList) 0 }}
+{{- .Values.nodeAttestor.k8sPsat.serviceAccountAllowList | toJson }}
 {{- else }}
 [{{ printf "%s:%s-agent" .Release.Namespace .Release.Name | quote }}]
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -92,3 +92,11 @@ Create the name of the service account to use
 {{- define "spire-k8s-workload-registrar.fullname" -}}
 {{ include "spire-server.fullname" . | trimSuffix "-server" }}-k8s-workload-registrar
 {{- end }}
+
+{{- define "spire-server.serviceAccountAllowedList" }}
+{{- if ne (len .Values.nodeAttestor.k8sPsat.serviceAccountsAllowed) 0 }}
+{{- .Values.nodeAttestor.k8sPsat.serviceAccountsAllowed | toJson }}
+{{- else }}
+[{{ printf "%s:%s-agent" .Release.Namespace .Release.Name | quote }}]
+{{- end }}
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
         plugin_data {
           clusters = {
             {{ .Values.clusterName | quote }} = {
-              service_account_allow_list = ["{{ .Release.Namespace }}:{{ .Release.Name }}-agent"]
+              service_account_allow_list = {{ include "spire-server.serviceAccountAllowedList" . | trim }}
             }
           }
         }

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -177,3 +177,7 @@ extraVolumeMounts: []
 extraContainers: []
 
 initContainers: []
+
+nodeAttestor:
+  k8sPsat:
+    serviceAccountsAllowed: []

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -180,4 +180,4 @@ initContainers: []
 
 nodeAttestor:
   k8sPsat:
-    serviceAccountsAllowed: []
+    serviceAccountAllowList: []


### PR DESCRIPTION
If you don't have the agent and server in the same namespace or the same cluster, or want to bind additional clusters, you need the ability to configure the service account allow list.