### PR TITLE
Make the namespace the bundle is dropped into configurable

### DIFF
--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -63,6 +63,7 @@ A Helm chart to install the SPIRE server.
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| notifier.k8sbundle.namespace | string | `""` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` | SPIRE server currently runs with a sqlite database. Scaling to multiple instances will not work until we use an external database. |

--- a/charts/spire/charts/spire-server/templates/bundle-configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/bundle-configmap.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.bundleConfigMap }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.notifier.k8sbundle.namespace | default .Release.Namespace }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -54,7 +54,7 @@ data:
 
       Notifier "k8sbundle" {
         plugin_data {
-          namespace = {{ .Release.Namespace | quote }}
+          namespace = {{ .Values.notifier.k8sbundle.namespace | default .Release.Namespace | quote }}
           config_map = {{ .Values.bundleConfigMap | quote }}
         }
       }

--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -3,13 +3,22 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}-pods
   namespace: {{ .Release.Namespace }}
 rules:
   # allow "get" access to pods (to resolve selectors for PSAT attestation)
   - apiGroups: [""]
     resources: [pods]
     verbs: [get]
+    # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
+    # agent bootstrapping, see the spire-bundle ConfigMap below)
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spire-server.fullname" . }}-bundle
+  namespace: {{ .Values.notifier.k8sbundle.namespace | default .Release.Namespace }}
+rules:
     # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
     # agent bootstrapping, see the spire-bundle ConfigMap below)
   - apiGroups: [""]
@@ -34,7 +43,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}-pods
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
@@ -43,6 +52,20 @@ subjects:
 roleRef:
   kind: Role
   name: {{ include "spire-server.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spire-server.fullname" . }}-bundle
+  namespace: {{ .Values.notifier.k8sbundle.namespace | default .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spire-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "spire-server.fullname" . }}-bundle
   apiGroup: rbac.authorization.k8s.io
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -115,6 +115,10 @@ upstreamAuthority:
     namespace: ""
     kube_config_file: ""
 
+notifier:
+  k8sbundle:
+    namespace: ""
+
 controllerManager:
   enabled: false
 


### PR DESCRIPTION
When the server and agent are not in the same namespace, the bundle needs to be uploadable in the agent's namespace.