### PR TITLE
Add option to enable federation on spire-server

### DIFF
--- a/.github/tests/federation-bundle-endpoint/values.yaml
+++ b/.github/tests/federation-bundle-endpoint/values.yaml
@@ -1,0 +1,3 @@
+spire-server:
+  federation:
+    enabled: true

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -56,6 +56,9 @@ A Helm chart to install the SPIRE server.
 | extraContainers | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| federation.bundleEndpoint.address | string | `"0.0.0.0"` |  |
+| federation.bundleEndpoint.port | int | `8443` |  |
+| federation.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -29,6 +29,17 @@ data:
         common_name = {{ .common_name | quote }},
         {{- end }}
       }
+
+      {{- with .Values.federation }}
+      {{- if eq (.enabled | toString) "true" }}
+      federation {
+        bundle_endpoint {
+          address = "{{ .bundleEndpoint.address }}"
+          port = {{ .bundleEndpoint.port }}
+        }
+      }
+      {{- end }}
+      {{- end }}
     }
 
     plugins {

--- a/charts/spire/charts/spire-server/templates/service.yaml
+++ b/charts/spire/charts/spire-server/templates/service.yaml
@@ -16,5 +16,13 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: grpc
       protocol: TCP
+    {{- with .Values.federation }}
+    {{- if eq (.enabled | toString) "true" }}
+    - name: federation
+      port: {{ .bundleEndpoint.port }}
+      targetPort: federation
+      protocol: TCP
+    {{- end }}
+    {{- end }}
   selector:
     {{- include "spire-server.selectorLabels" . | nindent 4 }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -57,6 +57,13 @@ spec:
               protocol: TCP
             - containerPort: 8080
               name: healthz
+            {{- with .Values.federation }}
+            {{- if eq (.enabled | toString) "true" }}
+            - name: federation
+              containerPort: {{ .bundleEndpoint.port }}
+              protocol: TCP
+            {{- end }}
+            {{- end }}
             {{- if (dig "telemetry" "prometheus" "enabled" .Values.telemetry.prometheus.enabled .Values.global) }}
             - containerPort: 9988
               name: prom

--- a/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
@@ -17,4 +17,12 @@ spec:
       args: ['-zvw3', '{{ include "spire-server.fullname" . }}', '{{ .Values.service.port }}']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- if eq (.Values.federation.enabled | toString) "true" }}
+    - name: wget-federation-bundle-endpoint
+      image: busybox
+      command: ['wget']
+      args: ['--no-check-certificate', '-O', '/dev/null', 'https://{{ include "spire-server.fullname" . }}.{{ include "spire-server.namespace" . }}.svc.cluster.local:{{ .Values.federation.bundleEndpoint.port }}']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- end }}
   restartPolicy: Never

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -87,6 +87,12 @@ trustDomain: example.org
 
 bundleConfigMap: spire-server
 
+federation:
+  enabled: false
+  bundleEndpoint:
+    port: 8443
+    address: "0.0.0.0"
+
 ca_subject:
   country: NL
   organization: Example


### PR DESCRIPTION
Adds an option to enable the federation bundle endpoint in `server.conf` along with matching entries in the `Service` and `StatefulSet`.
