### PR TITLE
Remove dead role code

### DIFF
--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -6,10 +6,6 @@ metadata:
   name: {{ include "spire-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
-  # allow "get" access to pods (to resolve selectors for PSAT attestation)
-  - apiGroups: [""]
-    resources: [pods]
-    verbs: [get]
     # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
     # agent bootstrapping, see the spire-bundle ConfigMap below)
   - apiGroups: [""]


### PR DESCRIPTION
The cluster role does the same thing, but at the cluster level where it belongs. The extra role code does nothing so we remove it here.