### PR TITLE
Add tmp mount so that server can run locked down

### DIFF
--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -132,6 +132,9 @@ spec:
               mountPath: /controller-manager-config.yaml
               subPath: controller-manager-config.yaml
               readOnly: true
+            - name: spire-controller-manager-tmp
+              mountPath: /tmp
+              readOnly: false
         {{- end }}
         {{- if gt (len .Values.extraContainers) 0 }}
         {{- toYaml .Values.extraContainers | nindent 8 }}
@@ -157,6 +160,8 @@ spec:
           configMap:
             name: {{ include "spire-server.fullname" . }}
         - name: spire-server-socket
+          emptyDir: {}
+        - name: spire-controller-manager-tmp
           emptyDir: {}
         {{- if eq (.Values.upstreamAuthority.disk.enabled | toString) "true" }}
         - name: upstream-ca


### PR DESCRIPTION
This pr adds a tmp mount to the spire server pod so that it can run with read only root.