### PR TITLE
Fix the tests so they can run locked down.

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -25,7 +25,7 @@ spec:
     - name: wget-service-name-namespace-svc-cluster-local
       image: busybox
       command: ['wget']
-      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -25,7 +25,7 @@ spec:
     - name: wget-service-name-namespace-svc-cluster-local
       image: busybox
       command: ['wget']
-      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -7,17 +7,25 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: wget-service-name
       image: busybox
       command: ['wget']
-      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
     - name: wget-service-name-namespace
       image: busybox
       command: ['wget']
-      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
     - name: wget-service-name-namespace-svc-cluster-local
       image: busybox
       command: ['wget']
-      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
+      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never

--- a/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
@@ -7,9 +7,13 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: wget
       image: busybox
       command: ['nc']
       args: ['-zvw3', '{{ include "spire-server.fullname" . }}', '{{ .Values.service.port }}']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never


### PR DESCRIPTION
The tests need to be able to run with locked down settings to run in a locked down namespace. This patch adds that capability.