### PR TITLE
Improve Chart API

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -15,7 +15,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| agentSocket | string | `"spire-agent.sock"` |  |
+| agentSocketName | string | `"spire-agent.sock"` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `5` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/_helpers.tpl
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/_helpers.tpl
@@ -83,3 +83,7 @@ Create the name of the service account to use
 {{- printf "%s/%s" .image.registry .image.repository -}}
 {{- end -}}
 {{- end }}
+
+{{- define "spiffe-oidc-discovery-provider.workload-api-socket-path" -}}
+{{- printf "/spiffe-workload-api/%s" .Values.agentSocketName }}
+{{- end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
     {{- end }}
 
     workload_api {
-      socket_path = "/spiffe-workload-api/{{ .Values.agentSocket }}"
+      socket_path = {{ include "spiffe-oidc-discovery-provider.workload-api-socket-path" . | quote }}
       trust_domain = "{{ .Values.trustDomain }}"
     }
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: spiffe-workload-api
-              mountPath: /spiffe-workload-api
+              mountPath: {{ include "spiffe-oidc-discovery-provider.workload-api-socket-path" . | dir }}
               readOnly: true
             - name: spire-oidc-sockets
               mountPath: /run/spire/oidc-sockets

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-agentSocket: spire-agent.sock
+agentSocketName: spire-agent.sock
 
 replicaCount: 1
 

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -14,7 +14,6 @@ A Helm chart to install the SPIRE agent.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
 | bundleConfigMap | string | `"spire-bundle"` |  |
 | clusterName | string | `"example-cluster"` |  |
 | extraContainers | list | `[]` |  |
@@ -43,6 +42,7 @@ A Helm chart to install the SPIRE agent.
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
 | telemetry.prometheus.enabled | bool | `false` |  |
 | telemetry.prometheus.port | int | `9988` |  |
 | trustDomain | string | `"example.org"` |  |

--- a/charts/spire/charts/spire-agent/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-agent/templates/_helpers.tpl
@@ -100,6 +100,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "spire-agent.agent-socket-path" -}}
-{{- print .Values.agentSocketPath }}
+{{- define "spire-agent.socket-path" -}}
+{{- print .Values.socketPath }}
 {{- end }}

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
       log_level = {{ .Values.logLevel | quote }}
       server_address = {{ include "spire-agent.server-address" . | trim | quote }}
       server_port = {{ .Values.server.port | quote }}
-      socket_path = {{ include "spire-agent.agent-socket-path" . | quote }}
+      socket_path = {{ include "spire-agent.socket-path" . | quote }}
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = {{ .Values.trustDomain | quote }}
     }

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
               mountPath: /run/spire/bundle
               readOnly: true
             - name: spire-agent-socket-dir
-              mountPath: {{ include "spire-agent.agent-socket-path" . | dir }}
+              mountPath: {{ include "spire-agent.socket-path" . | dir }}
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens
@@ -110,7 +110,7 @@ spec:
                 audience: spire-server
         - name: spire-agent-socket-dir
           hostPath:
-            path: {{ include "spire-agent.agent-socket-path" . | dir }}
+            path: {{ include "spire-agent.socket-path" . | dir }}
             type: DirectoryOrCreate
         {{- if gt (len .Values.extraVolumes) 0 }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -87,7 +87,7 @@ telemetry:
     enabled: false
     port: 9988
 
-agentSocketPath: /run/spire/agent-sockets/spire-agent.sock
+socketPath: /run/spire/agent-sockets/spire-agent.sock
 
 # -- Priority class assigned to daemonset pods
 priorityClassName: ""


### PR DESCRIPTION
Because we are already in the context of spire-agent the API looks more logical to not have another 'agent' part in the name.

Furthermore to make it more clear the oidc provider only requires the name of the socket as opposed to the entire path like in the other charts I made that more explicit in the name of the value.
