### PR TITLE
Fix the driver not coming up on overloaded nodes

### DIFF
--- a/examples/production/values.yaml
+++ b/examples/production/values.yaml
@@ -50,6 +50,7 @@ spire-server:
 spiffe-csi-driver:
   enabled: true
   namespaceOverride: spire-system
+  priorityClassName: system-node-critical
 
 spire-agent:
   enabled: true
@@ -58,3 +59,4 @@ spire-agent:
     name: spire-agent
   server:
     namespaceOverride: spire-server
+  priorityClassName: system-node-critical


### PR DESCRIPTION
Add to the reference production example a fix for overloaded nodes.

fixes: https://github.com/spiffe/helm-charts/issues/80