### PR TITLE
Add hooks to set failurepolicy to ignore on webhook

### DIFF
--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -49,6 +49,10 @@ A Helm chart to install the SPIRE server.
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"bitnami"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"kubectl"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
 | dataStorage.accessMode | string | `"ReadWriteOnce"` |  |
 | dataStorage.enabled | bool | `true` |  |
 | dataStorage.size | string | `"1Gi"` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -50,8 +50,8 @@ A Helm chart to install the SPIRE server.
 | controllerManager.service.type | string | `"ClusterIP"` |  |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"bitnami"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"kubectl"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` |  |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
 | dataStorage.accessMode | string | `"ReadWriteOnce"` |  |
 | dataStorage.enabled | bool | `true` |  |

--- a/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
@@ -24,7 +24,7 @@ webhooks:
         name: {{ include "spire-controller-manager.fullname" . }}-webhook
         namespace: {{ include "spire-server.namespace" . }}
         path: /validate-spire-spiffe-io-v1alpha1-clusterspiffeid
-    failurePolicy: {{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}
+    failurePolicy: Ignore
     name: vclusterspiffeid.kb.io
     rules:
       - apiGroups: ["spire.spiffe.io"]

--- a/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
@@ -24,7 +24,7 @@ webhooks:
         name: {{ include "spire-controller-manager.fullname" . }}-webhook
         namespace: {{ include "spire-server.namespace" . }}
         path: /validate-spire-spiffe-io-v1alpha1-clusterspiffeid
-    failurePolicy: Ignore
+    failurePolicy: Ignore # Actual value to be set by post install/upgrade hooks
     name: vclusterspiffeid.kb.io
     rules:
       - apiGroups: ["spire.spiffe.io"]

--- a/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
@@ -10,7 +10,7 @@ webhooks:
         name: {{ include "spire-controller-manager.fullname" . }}-webhook
         namespace: {{ include "spire-server.namespace" . }}
         path: /validate-spire-spiffe-io-v1alpha1-clusterfederatedtrustdomain
-    failurePolicy: {{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}
+    failurePolicy: Ignore # Actual value to be set by post install/upgrade hooks
     name: vclusterfederatedtrustdomain.kb.io
     rules:
       - apiGroups: ["spire.spiffe.io"]

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -59,7 +59,7 @@ spec:
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-install
       containers:
       - name: post-install-job
-        image: bitnami/kubectl
+        image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh
         - -c

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -68,6 +68,18 @@ spec:
         - /bin/sh
         - -c
         - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"}]}'
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
+          {
+            "webhooks":[
+              {
+                "name":"vclusterspiffeid.kb.io",
+                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+              },
+              {
+                "name":"vclusterfederatedtrustdomain.kb.io",
+                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+              }
+            ]
+          }'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -64,6 +64,6 @@ spec:
         - /bin/sh
         - -c
         - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"}]}'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -21,6 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
+    resourceNames: [{{ printf "%s-webhook"  (include "spire-controller-manager.fullname" .) | quote }}]
     verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -1,0 +1,66 @@
+{{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spire-server.serviceAccountName" . }}-post-install
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-install
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-install
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spire-server.serviceAccountName" . }}-post-install
+    namespace: {{ include "spire-server.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "spire-server.fullname" . }}-post-install
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-install
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ include "spire-server.fullname" . }}-post-install
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-install
+      containers:
+      - name: post-install-job
+        image: bitnami/kubectl
+        command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -57,8 +57,12 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-install
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: post-install-job
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -21,7 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -63,7 +63,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
+        - |-
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -1,4 +1,5 @@
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+{{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -63,4 +64,5 @@ spec:
         - -c
         - |
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -1,0 +1,66 @@
+{{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spire-server.serviceAccountName" . }}-post-upgrade
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-upgrade
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-upgrade
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spire-server.serviceAccountName" . }}-post-upgrade
+    namespace: {{ include "spire-server.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "spire-server.fullname" . }}-post-upgrade
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "spire-server.fullname" . }}-post-upgrade
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ include "spire-server.fullname" . }}-post-upgrade
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-upgrade 
+      containers:
+      - name: post-upgrade-job
+        image: bitnami/kubectl
+        command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -68,6 +68,18 @@ spec:
         - /bin/sh
         - -c
         - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"}]}'
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
+          {
+            "webhooks":[
+              {
+                "name":"vclusterspiffeid.kb.io",
+                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+              },
+              {
+                "name":"vclusterfederatedtrustdomain.kb.io",
+                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+              }
+            ]
+          }'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -64,6 +64,6 @@ spec:
         - /bin/sh
         - -c
         - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"}]}'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -21,6 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
+    resourceNames: [{{ printf "%s-webhook"  (include "spire-controller-manager.fullname" .) | quote }}]
     verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -59,7 +59,7 @@ spec:
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-upgrade 
       containers:
       - name: post-upgrade-job
-        image: bitnami/kubectl
+        image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh
         - -c

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -21,7 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -63,7 +63,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
+        - |-
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -57,8 +57,12 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-upgrade 
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: post-upgrade-job
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -1,4 +1,5 @@
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+{{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -63,4 +64,5 @@ spec:
         - -c
         - |
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p "{\"webhooks\":[{\"name\":\"vclusterspiffeid.kb.io\",\"failurePolicy\":\"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}\"}]}"
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -59,7 +59,7 @@ spec:
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
       containers:
       - name: post-install-job
-        image: bitnami/kubectl
+        image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh
         - -c

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -21,6 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
+    resourceNames: [{{ printf "%s-webhook"  (include "spire-controller-manager.fullname" .) | quote }}]
     verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -1,0 +1,66 @@
+{{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "spire-server.fullname" . }}-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spire-server.fullname" . }}-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
+    namespace: {{ include "spire-server.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "spire-server.fullname" . }}-pre-upgrade
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "spire-server.fullname" . }}-pre-upgrade
+  namespace: {{ include "spire-server.namespace" . }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ include "spire-server.fullname" . }}-pre-upgrade
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
+      containers:
+      - name: post-install-job
+        image: bitnami/kubectl
+        command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"Ignore"}]}'
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -21,7 +21,7 @@ metadata:
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -1,4 +1,5 @@
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
+{{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -63,4 +64,5 @@ spec:
         - -c
         - |
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"Ignore"}]}'
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -63,7 +63,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
+        - |-
           kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"Ignore"}]}'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -68,6 +68,18 @@ spec:
         - /bin/sh
         - -c
         - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '{"webhooks":[{"name":"vclusterspiffeid.kb.io","failurePolicy":"Ignore"}]}'
+          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
+          {
+            "webhooks":[
+              {
+                "name":"vclusterspiffeid.kb.io",
+                "failurePolicy":"Ignore"
+              },
+              {
+                "name":"vclusterfederatedtrustdomain.kb.io",
+                "failurePolicy":"Ignore"
+              }
+            ]
+          }'
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -57,8 +57,12 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: post-install-job
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         image: {{ template "spire-server.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image) }}
         command:
         - /bin/sh

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -187,11 +187,10 @@ controllerManager:
     failurePolicy: Fail
     upgradeHook:
       image:
-        registry: "bitnami"
-        repository: kubectl
+        registry: cgr.dev
+        repository: chainguard/kubectl
         pullPolicy: IfNotPresent
-        # Overrides the image tag whose default is the chart appVersion.
-        version: "latest"
+        version: latest
 
 telemetry:
   prometheus:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -185,6 +185,13 @@ controllerManager:
 
   validatingWebhookConfiguration:
     failurePolicy: Fail
+    upgradeHook:
+      image:
+        registry: "bitnami"
+        repository: kubectl
+        pullPolicy: IfNotPresent
+        # Overrides the image tag whose default is the chart appVersion.
+        version: "latest"
 
 telemetry:
   prometheus:


### PR DESCRIPTION
Adds a set of 3 hooks to address upgrade failure issues. Workflow:

- Set failurePolicy on the webhook to `Ignore` in the template yaml
- Post-install hook sets it to `{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}`
- Pre-upgrade sets it to `Ignore`
- Post-upgrade sets it back to `{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}`

I thought this was the most deterministic way to workaround this issue. 

We could potentially have only the pre upgrade hook if we ensure that the clusterspiffeid is always installed/upgraded before the webhook. Right now this is the case as helm determines install order by filesystem order and `controller-manager-cluster-ids.yaml` comes before `controller-manager-webhook.yaml`. Relying on file names seems error prone to me though. What do you think?

fixes https://github.com/spiffe/helm-charts/issues/72