### PR TITLE
Bump spire Helm Chart version from 0.4.0 to 0.5.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.5.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.5](https://img.shields.io/badge/AppVersion-1.5.5-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.5](https://img.shields.io/badge/AppVersion-1.5.5-informational?style=flat-square)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* fae12af Merge pull request #60 from spiffe/oidc-ingress
* 6322a9a Fix tests
* a9b99fe Add some commented lines for best practice annotations on ingress
* e970d52 Align ingress hostname with jwtIssues in spire-server chart
* cc7121e Add ingress support for OIDC discovery provider
* eaed7c9 Bump actions/checkout from 3.3.0 to 3.4.0 (#129)
* 2e3f045 Make webhook fail policy configurable (#124)
* 9ccbd3c Make kubelet path configurable (#123)
* 80e3b58 Remove dead file from failed rebase. (#121)
* 7155d71 Add documentation how to use Spire in own workloads
* 25c77fc Fix the driver not coming up on overloaded nodes
* 5fdd35b Improve Chart API (#119)
* 03db6bb Namespace override
* 661000a Make the agent socket configurable (#114)
* f3a81ad Make csi driver configurable to be able to run multiple instances (#115)
* b198bc7 Fix the tests so they can run locked down. (#111)
* 09b21ac Fix the gate
* b6716ae Test that it is possible to lock down security of pods (#84)
* bfeb217 Fix cluster role name uniqueness
* 490fe8f Enhance the test workflow scripts
* 9e22d2c Make the namespace the bundle is dropped into configurable
* 7d1f821 Fix test.
* 493ad8f Remove some duplication on chart-testing CI
* b6dd136 Add tmp mount so that server can run locked down (#105)
* aaaf2f7 Remove dead role code
* d2eba22 Fix docs
* 6d43625 Add kfox as a maintainer
* dfa4e6c Ensure CI also runs when test scripts are changed
