### PR TITLE
Remove k8s 1.21 from test matrix + small syntax error fix

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -161,8 +161,9 @@ jobs:
           trap 'post-install $? $LINENO' EXIT
           [ -x "${TEST_DIR}/pre-install.sh" ] && "${TEST_DIR}/pre-install.sh"
           [ -f "${TEST_DIR}/.env" ] && source "${TEST_DIR}/.env"
-          if [ -x {${TEST_DIR}/install.sh ]; then
-            ./${TEST_DIR}/install.sh
+
+          if [ -x "${TEST_DIR}/install.sh" ]; then
+            "${TEST_DIR}/install.sh"
           else
             ct install --debug \
               --namespace "${scenario}" \

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -116,7 +116,6 @@ jobs:
           - v1.24.7
           - v1.23.13
           - v1.22.15
-          - v1.21.14
         values:
           - ${{ fromJson(needs.build-matrix.outputs.tests) }}
 

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -151,14 +151,17 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |
-          export scenario="$(basename "${TEST_DIR}")"
-          export EXTRA_HELM_ARGS=""
-          [ "${scenario}" != "default" ] && kubectl create namespace "${scenario}"
           post-install() {
             [ -x "${TEST_DIR}/post-install.sh" ] && "${TEST_DIR}/post-install.sh" $1
             exit $1
           }
+
           trap 'post-install $? $LINENO' EXIT
+
+          export scenario="$(basename "${TEST_DIR}")"
+          export EXTRA_HELM_ARGS=""
+
+          [ "${scenario}" != "default" ] && kubectl create namespace "${scenario}"
           [ -x "${TEST_DIR}/pre-install.sh" ] && "${TEST_DIR}/pre-install.sh"
           [ -f "${TEST_DIR}/.env" ] && source "${TEST_DIR}/.env"
 


### PR DESCRIPTION
- Remove k8s 1.21 from test matrix
- Fix syntax
- Improve readability test step

Officialy according to readme we support last three k8s versions.
Testing last 5 versions should be sufficient.