### PR TITLE
Add artifacthub-repo.yml file with initial list of owners

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,23 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: 7132447f-33ea-48e5-b042-4fb64c3ed8a4
+owners:
+  - name: Daniel Feldman
+    email: dfeldman.mn@gmail.com
+  - name: Faisal Memon
+    email: fymemon@yahoo.com
+  - name: Mariusz Sabath
+    email: mrsabath@gmail.com
+  - name: Batuhan Apaydın
+    email: developerguyn@gmail.com
+  - name: Marco Franssen
+    email: marco.franssen@gmail.com


### PR DESCRIPTION
Modified to point to a repo called "spire" rather than a repo called "spiffe"
Feel free to add yourself to the email list 