### PR TITLE
Cut patch release for 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Unless otherwise noted in an application chart README, the following dependencie
 
 | Dependency | Supported Versions |
 |:-----------|:-------------------|
-| SPIRE      | `1.5.x`, `1.6.x`   |
+| SPIRE      | `1.5.3`+, `1.6.x`  |
 | Helm       | `3.x`              |
 
 For Kubernetes we will officially try to support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions).

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.6.1"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
 version: 0.5.0
-appVersion: "1.5.5"
+appVersion: "1.6.1"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -3,14 +3,26 @@
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
 ![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
+[![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 **Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
 
-> **Warning**: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
+## Version support
 
-> **Note**: Minimum Spire version is `v1.5.3`.
+> **Note**: This Chart is still in development and still subject to change the API (`values.yaml`).
+> Until we reach a `1.0.0` version of the chart we can't guarantee backwards compatibility although
+> we do aim for as much stability as possible.
+
+| Dependency | Supported Versions |
+|:-----------|:-------------------|
+| SPIRE      | `1.5.3+`, `1.6.x`  |
+| Helm       | `3.x`              |
+
+## Prerequisites
+
+Please note this chart requires `Projected Service Account Tokens` which has to be enabled on your k8s api server.
 
 To enable Projected Service Account Tokens on Docker for Mac/Windows run the following
 command to SSH into the Docker Desktop K8s VM.

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.5](https://img.shields.io/badge/AppVersion-1.5.5-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.

--- a/charts/spire/README.md.gotmpl
+++ b/charts/spire/README.md.gotmpl
@@ -5,14 +5,26 @@
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}
+[![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}
 
-> **Warning**: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
+## Version support
 
-> **Note**: Minimum Spire version is `v1.5.3`.
+> **Note**: This Chart is still in development and still subject to change the API (`values.yaml`).
+> Until we reach a `1.0.0` version of the chart we can't guarantee backwards compatibility although
+> we do aim for as much stability as possible.
+
+| Dependency | Supported Versions |
+|:-----------|:-------------------|
+| SPIRE      | `1.5.3+`, `1.6.x`  |
+| Helm       | `3.x`              |
+
+## Prerequisites
+
+Please note this chart requires `Projected Service Account Tokens` which has to be enabled on your k8s api server.
 
 To enable Projected Service Account Tokens on Docker for Mac/Windows run the following
 command to SSH into the Docker Desktop K8s VM.

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
@@ -3,4 +3,4 @@ name: spiffe-oidc-discovery-provider
 description: A Helm chart to install the SPIFFE OIDC discovery provider.
 type: application
 version: 0.1.0
-appVersion: "1.6.0"
+appVersion: "1.6.1"

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 A Helm chart to install the SPIFFE OIDC discovery provider.
 

--- a/charts/spire/charts/spire-agent/Chart.yaml
+++ b/charts/spire/charts/spire-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: spire-agent
 description: A Helm chart to install the SPIRE agent.
 type: application
 version: 0.1.0
-appVersion: "1.6.0"
+appVersion: "1.6.1"

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 A Helm chart to install the SPIRE agent.
 

--- a/charts/spire/charts/spire-server/Chart.yaml
+++ b/charts/spire/charts/spire-server/Chart.yaml
@@ -3,4 +3,4 @@ name: spire-server
 description: A Helm chart to install the SPIRE server.
 type: application
 version: 0.1.0
-appVersion: "1.6.0"
+appVersion: "1.6.1"

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 A Helm chart to install the SPIRE server.
 


### PR DESCRIPTION
- Bump spire version to 1.6.1
- Improve Spire Chart documentation
- Bump spire Helm Chart version from 0.5.0 to 0.5.1

These commits are cherry-picked from the already reviewed PRs.

- #173 
- #161
- #160 

> **Warning**: Please merge using a **merge commit** to maintain the cherry-picking references to reduce chance of future merge conflicts.