### PR TITLE
Switch tests to curl

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -11,29 +11,29 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-    - name: wget-service-name
+    - name: curl-service-name
       image: cgr.dev/chainguard/bash:latest
-      command: ['wget']
-      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      command: ['curl']
+      args: ['-s', '-f', 'http://{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-    - name: wget-service-name-namespace
+    - name: curl-service-name-namespace
       image: cgr.dev/chainguard/bash:latest
-      command: ['wget']
-      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+      command: ['curl']
+      args: ['-s', '-f', 'http://{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-    - name: wget-service-name-namespace-svc-cluster-local
+    - name: curl-service-name-namespace-svc-cluster-local
       image: cgr.dev/chainguard/bash:latest
-      command: ['wget']
-      args: ['-O', '/dev/null', '{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
+      command: ['curl']
+      args: ['-s', '-f', 'http://{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ include "spiffe-oidc-discovery-provider.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     {{- if .Values.ingress.enabled }}
-    - name: wget-ingress
+    - name: curl-ingress
       image: cgr.dev/chainguard/bash:latest
-      command: ['wget']
-      args: ['-O', '/dev/null', '{{ index .Values.config.domains 0 }}/.well-known/openid-configuration']
+      command: ['curl']
+      args: ['-s', '-f', 'http://{{ index .Values.config.domains 0 }}/.well-known/openid-configuration']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     {{- end }}

--- a/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-connection.yaml
@@ -11,10 +11,22 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-    - name: netcat
+    - name: curl
       image: cgr.dev/chainguard/bash:latest
-      command: ['nc']
-      args: ['-zvw3', '{{ include "spire-server.fullname" . }}', '{{ .Values.service.port }}']
+      command: ['bash']
+      args:
+        - -c
+        - |
+          curl -f -s 'https://{{ include "spire-server.fullname" . }}:{{ .Values.service.port }}'
+          NOCA=$?
+          curl -k -f -s 'https://{{ include "spire-server.fullname" . }}:{{ .Values.service.port }}'
+          IGNORECA=$?
+          echo $NOCA $IGNORECA
+          if [ $NOCA -eq 60 -a $IGNORECA -eq 22 ]; then
+            # We were able to connect to the server but didn't recognize the ca (60) and the page not found (22) because we're not using grpc
+            exit 0
+          fi
+          exit 1
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     {{- if eq (.Values.federation.enabled | toString) "true" }}


### PR DESCRIPTION
The spire-server test now tests more things. The rest of the tests are converted to curl too 
for consistency.
