### PR TITLE
Add Kubernetes 1.21 back

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -152,6 +152,7 @@ jobs:
           - v1.24.7
           - v1.23.13
           - v1.22.15
+          - v1.21.14
         values:
           - ${{ fromJson(needs.build-matrix.outputs.tests) }}
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Unless otherwise noted in an application chart README, the following dependencie
 |:-----------|:-------------------|
 | SPIRE      | `1.5.3`+, `1.6.x`  |
 | Helm       | `3.x`              |
-| Kubernetes | `1.21` - `1.26`    |
+| Kubernetes | `1.21+`         |
+
+> **Note**: For Kubernetes we will officially support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions). Any version before the last 3 we will try to support as long it doesn't bring security issues or any big maintenance burden. *(The first version we tested this chart with is `1.21`)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Unless otherwise noted in an application chart README, the following dependencie
 |:-----------|:-------------------|
 | SPIRE      | `1.5.3`+, `1.6.x`  |
 | Helm       | `3.x`              |
-
-For Kubernetes we will officially try to support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions).
+| Kubernetes | `1.21` - `1.26`    |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Unless otherwise noted in an application chart README, the following dependencie
 |:-----------|:-------------------|
 | SPIRE      | `1.5.3`+, `1.6.x`  |
 | Helm       | `3.x`              |
-| Kubernetes | `1.21+`         |
+| Kubernetes | `1.21+`            |
 
-> **Note**: For Kubernetes we will officially support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions). Any version before the last 3 we will try to support as long it doesn't bring security issues or any big maintenance burden. *(The first version we tested this chart with is `1.21`)*
+> **Note**: For Kubernetes, we will officially support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions). Any version before the last 3 we will try to support as long it doesn't bring security issues or any big maintenance burden. *The first version we tested this chart with is `1.21`.*
 
 ## Contributing
 

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -19,6 +19,9 @@ A Helm chart for deploying the complete Spire stack including: spire-server, spi
 |:-----------|:-------------------|
 | SPIRE      | `1.5.3+`, `1.6.x`  |
 | Helm       | `3.x`              |
+| Kubernetes | `1.21+`            |
+
+> **Note**: For Kubernetes, we will officially support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions). Any version before the last 3 we will try to support as long it doesn't bring security issues or any big maintenance burden. *The first version we tested this chart with is `1.21`.*
 
 ## Prerequisites
 

--- a/charts/spire/README.md.gotmpl
+++ b/charts/spire/README.md.gotmpl
@@ -21,6 +21,9 @@
 |:-----------|:-------------------|
 | SPIRE      | `1.5.3+`, `1.6.x`  |
 | Helm       | `3.x`              |
+| Kubernetes | `1.21+`            |
+
+> **Note**: For Kubernetes, we will officially support the last 3 versions as described in [k8s versioning](https://kubernetes.io/releases/version-skew-policy/#supported-versions). Any version before the last 3 we will try to support as long it doesn't bring security issues or any big maintenance burden. *The first version we tested this chart with is `1.21`.*
 
 ## Prerequisites
 


### PR DESCRIPTION
Adds Kubernetes 1.21 back to the test matrix and as a supported version in the main readme.