### PR TITLE
Bump spire Helm Chart version from 0.5.1 to 0.6.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: "1.6.1"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* 563e1f7 Add podmonitors (#165)
* 456075f Add hooks to set failurepolicy to ignore on webhook (#128)
* d5dc706 Add Kubernetes 1.21 back (#188)
* daa620b Fix production example test (#183)
* c661d0b Make service dns domain configurable (#164)
* ec236e9 Test for configurable images (#182)
* 280315c Fix namespace-override github test summary (#154)
* 072d952 Switch tests to curl (#178)
* 1b4bfb7 Cleanup old leftover to k8s-workload-registrar
* a770928 Switch busybox image to cgr.dev/chainguard/busybox:latest-glibc (#175)
* 8790416 Enable global config for clusterName, trustDomain, and bundleConfigMap (#156)
* b54c41a Enhance the production example
* dfb32dc Revert adding tornjak to be releasable (#180)
* 059d5fb Bump spire Helm Chart version from 0.5.0 to 0.5.1
* e2ec6ac Add a test to ensure the chart versions match (#163)
* 64585ba Fix formatting issues introduced with #152
* 0dac0db Improve Spire Chart documentation
* f709ed9 Bump actions/checkout from 3.4.0 to 3.5.0
* faef439 Bump helm/chart-testing-action from 2.3.1 to 2.4.0
* ae62dd1 Bump spire version to 1.6.1
* 02fda80 Add Artifact Hub badge to README.md
* 901e670 Disable default Tornjak deployment (#153)
* 05d0f47 Introduction of Tornjak to SPIRE Server helm charts (#144)
* b25dc77 Test fixing the tests (#148)
* b4be9ed Add maturity tag (#138)
* d4fd2ce Extract the namespace override test out of the old lockdown test. (#145)
* 4f85802 Update lockdown test to test the production example
* 04a1305 Fork the lockdown test to two tests as it is doing the work of 2 (#134)
* 64d0107 Resolve issue in prod example on volume mount (#143)
* 5b6708b Remove @dennisgove from CODEOWNERS (#140)
* a516caa Remove k8s 1.21 from test matrix + small syntax error fix (#133)
* 811a2f6 Add option to enable federation on spire-server (#97)
