### PR TITLE
Add  before-hook-creation delete policy

### DIFF
--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-post-install
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
@@ -30,7 +30,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-post-install
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}-post-install
@@ -49,7 +49,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-post-upgrade
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
@@ -30,7 +30,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-post-upgrade
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}-post-upgrade
@@ -49,7 +49,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-pre-upgrade
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
@@ -30,7 +30,7 @@ metadata:
   name: {{ include "spire-server.fullname" . }}-pre-upgrade
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}-pre-upgrade
@@ -49,7 +49,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   template:
     metadata:


### PR DESCRIPTION
Adds [before-hook-creation](https://helm.sh/docs/topics/charts_hooks/#:~:text=Description-,before%2Dhook%2Dcreation,Delete%20the%20previous%20resource%20before%20a%20new%20hook%20is%20launched%20(default),-hook%2Dsucceeded) to the delete policy to ensure all hook objects are delete prior to install/upgrade

Should fix https://github.com/spiffe/helm-charts/issues/197