### PR TITLE
Fix the helm version update script

### DIFF
--- a/.github/workflows/scripts/update-versions.sh
+++ b/.github/workflows/scripts/update-versions.sh
@@ -18,7 +18,7 @@ jq -r ".[].name" "${CHARTJSON}" | while read -r CHART; do
   echo "  latest version: $LATEST_VERSION"
   if [ "x$VERSION" != "x$LATEST_VERSION" ]; then
     echo "  New version found!"
-    jq "( $ENTRYQUERY ).version |= "'"${LATEST_VERSION}"' "${CHARTJSON}" > /tmp/$$
+    jq "( $ENTRYQUERY ).version |= "'"'${LATEST_VERSION}'"' "${CHARTJSON}" > /tmp/$$
     mv /tmp/$$ "${CHARTJSON}"
   fi
 done


### PR DESCRIPTION
The quoting was broken before a merge. This patch sets it back to what was tested before the change.