### PR TITLE
Add skipKubeletVerification configurable

### DIFF
--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -54,6 +54,7 @@ A Helm chart to install the SPIRE agent.
 | waitForIt.image.repository | string | `"chainguard/wait-for-it"` |  |
 | waitForIt.image.version | string | `"latest-20230113"` |  |
 | waitForIt.resources | object | `{}` |  |
+| workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |
 
 ----------------------------------------------

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -24,7 +24,7 @@ plugins:
           # Defaults to the secure kubelet port by default.
           # Minikube does not have a cert in the cluster CA bundle that
           # can authenticate the kubelet cert, so skip validation.
-          skip_kubelet_verification: true
+          skip_kubelet_verification: {{ .Values.workloadAttestors.k8s.skipKubeletVerification }}
 
   {{- if .Values.workloadAttestors.unix.enabled }}
     - unix:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -58,8 +58,6 @@ trustDomain: example.org
 
 bundleConfigMap: spire-bundle
 
-
-
 server:
   address: ""
   port: 8081

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -85,7 +85,7 @@ workloadAttestors:
     enabled: false
   k8s:
     # -- If true, kubelet certificate verification is skipped
-    skipKubeletVerification: false
+    skipKubeletVerification: true
 
 telemetry:
   prometheus:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -58,6 +58,8 @@ trustDomain: example.org
 
 bundleConfigMap: spire-bundle
 
+
+
 server:
   address: ""
   port: 8081
@@ -81,6 +83,9 @@ workloadAttestors:
   unix:
     # -- enables the Unix workload attestor
     enabled: false
+  k8s:
+    # -- If true, kubelet certificate verification is skipped
+    skipKubeletVerification: false
 
 telemetry:
   prometheus:


### PR DESCRIPTION
Adds new `k8s` section under `workloadAttestors` to allow `skip_kubelet_verification` to be configurable

fixes https://github.com/spiffe/helm-charts/issues/126