### PR TITLE
Switch image.version to image.tag

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -129,7 +129,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-csi-driver.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
-| spiffe-csi-driver.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| spiffe-csi-driver.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | spiffe-csi-driver.imagePullSecrets | list | `[]` |  |
 | spiffe-csi-driver.kubeletPath | string | `"/var/lib/kubelet"` |  |
 | spiffe-csi-driver.nameOverride | string | `""` |  |
@@ -137,7 +137,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
-| spiffe-csi-driver.nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.tag | string | `"v2.6.2"` |  |
 | spiffe-csi-driver.nodeDriverRegistrar.resources | object | `{}` |  |
 | spiffe-csi-driver.nodeSelector | object | `{}` |  |
 | spiffe-csi-driver.pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |
@@ -170,7 +170,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| spiffe-oidc-discovery-provider.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | spiffe-oidc-discovery-provider.imagePullSecrets | list | `[]` |  |
 | spiffe-oidc-discovery-provider.ingress.annotations | object | `{}` |  |
 | spiffe-oidc-discovery-provider.ingress.className | string | `""` |  |
@@ -183,7 +183,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` |  |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.nameOverride | string | `""` |  |
 | spiffe-oidc-discovery-provider.namespaceOverride | string | `""` |  |
@@ -203,7 +203,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.version | string | `"0.11.0"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
@@ -222,7 +222,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-agent.image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
-| spire-agent.image.version | string | `""` |  |
+| spire-agent.image.tag | string | `""` |  |
 | spire-agent.imagePullSecrets | list | `[]` |  |
 | spire-agent.initContainers | list | `[]` |  |
 | spire-agent.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -252,7 +252,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| spire-agent.waitForIt.image.version | string | `"latest-20230113"` |  |
+| spire-agent.waitForIt.image.tag | string | `"latest-20230113"` |  |
 | spire-agent.waitForIt.resources | object | `{}` |  |
 | spire-agent.workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | spire-agent.workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |
@@ -283,7 +283,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| spire-server.controllerManager.image.version | string | `"0.2.2"` |  |
+| spire-server.controllerManager.image.tag | string | `"0.2.2"` |  |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
@@ -293,7 +293,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -314,7 +314,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
-| spire-server.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| spire-server.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | spire-server.imagePullSecrets | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
 | spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -137,7 +137,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
-| spiffe-csi-driver.nodeDriverRegistrar.image.tag | string | `"v2.6.2"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.tag | string | `"v2.6.2"` | Overrides the image tag |
 | spiffe-csi-driver.nodeDriverRegistrar.resources | object | `{}` |  |
 | spiffe-csi-driver.nodeSelector | object | `{}` |  |
 | spiffe-csi-driver.pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |
@@ -183,7 +183,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` | Overrides the image tag |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.nameOverride | string | `""` |  |
 | spiffe-oidc-discovery-provider.namespaceOverride | string | `""` |  |
@@ -203,7 +203,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` | Overrides the image tag |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
@@ -222,7 +222,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-agent.image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
-| spire-agent.image.tag | string | `""` |  |
+| spire-agent.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | spire-agent.imagePullSecrets | list | `[]` |  |
 | spire-agent.initContainers | list | `[]` |  |
 | spire-agent.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -252,7 +252,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| spire-agent.waitForIt.image.tag | string | `"latest-20230113"` |  |
+| spire-agent.waitForIt.image.tag | string | `"latest"` | Overrides the image tag |
 | spire-agent.waitForIt.resources | object | `{}` |  |
 | spire-agent.workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | spire-agent.workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |
@@ -283,7 +283,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| spire-server.controllerManager.image.tag | string | `"0.2.2"` |  |
+| spire-server.controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
@@ -293,7 +293,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` | Overrides the image tag |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -357,8 +357,9 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.topologySpreadConstraints | list | `[]` |  |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) |
-| spire-server.tornjak.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"spiffe/tornjak-backend","version":"v1.2.0"}` | Tornjak API image |
-| spire-server.tornjak.image.version | string | `"v1.2.0"` | Overrides the image tag whose default is the chart appVersion. |
+| spire-server.tornjak.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"spiffe/tornjak-backend","tag":"v1.2.0","version":""}` | Tornjak API image |
+| spire-server.tornjak.image.tag | string | `"v1.2.0"` | Overrides the image tag |
+| spire-server.tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.tornjak.resources | object | `{}` |  |
 | spire-server.tornjak.service.annotations | object | `{}` |  |
 | spire-server.tornjak.service.port | int | `10000` |  |
@@ -381,7 +382,8 @@ Kubernetes: `>=1.21.0-0`
 | tornjak-frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | tornjak-frontend.image.registry | string | `"ghcr.io"` |  |
 | tornjak-frontend.image.repository | string | `"spiffe/tornjak-frontend"` |  |
-| tornjak-frontend.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| tornjak-frontend.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| tornjak-frontend.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak-frontend.imagePullSecrets | list | `[]` |  |
 | tornjak-frontend.labels | object | `{}` |  |
 | tornjak-frontend.nameOverride | string | `""` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -130,6 +130,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
 | spiffe-csi-driver.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| spiffe-csi-driver.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-csi-driver.imagePullSecrets | list | `[]` |  |
 | spiffe-csi-driver.kubeletPath | string | `"/var/lib/kubelet"` |  |
 | spiffe-csi-driver.nameOverride | string | `""` |  |
@@ -138,6 +139,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
 | spiffe-csi-driver.nodeDriverRegistrar.image.tag | string | `"v2.6.2"` | Overrides the image tag |
+| spiffe-csi-driver.nodeDriverRegistrar.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-csi-driver.nodeDriverRegistrar.resources | object | `{}` |  |
 | spiffe-csi-driver.nodeSelector | object | `{}` |  |
 | spiffe-csi-driver.pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |
@@ -171,6 +173,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
 | spiffe-oidc-discovery-provider.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| spiffe-oidc-discovery-provider.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.imagePullSecrets | list | `[]` |  |
 | spiffe-oidc-discovery-provider.ingress.annotations | object | `{}` |  |
 | spiffe-oidc-discovery-provider.ingress.className | string | `""` |  |
@@ -184,6 +187,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` | Overrides the image tag |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.nameOverride | string | `""` |  |
 | spiffe-oidc-discovery-provider.namespaceOverride | string | `""` |  |
@@ -204,6 +208,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` | Overrides the image tag |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
@@ -223,6 +228,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-agent.image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
 | spire-agent.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| spire-agent.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-agent.imagePullSecrets | list | `[]` |  |
 | spire-agent.initContainers | list | `[]` |  |
 | spire-agent.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -252,7 +258,8 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| spire-agent.waitForIt.image.tag | string | `"latest"` | Overrides the image tag |
+| spire-agent.waitForIt.image.tag | string | `"latest-20230517"` | Overrides the image tag |
+| spire-agent.waitForIt.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-agent.waitForIt.resources | object | `{}` |  |
 | spire-agent.workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | spire-agent.workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |
@@ -284,6 +291,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | spire-server.controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
+| spire-server.controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
@@ -293,7 +301,8 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` | Overrides the image tag |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `""` | Overrides the image tag |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -315,6 +324,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
 | spire-server.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| spire-server.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.imagePullSecrets | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
 | spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -27,7 +27,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
-| nodeDriverRegistrar.image.tag | string | `"v2.6.2"` |  |
+| nodeDriverRegistrar.image.tag | string | `"v2.6.2"` | Overrides the image tag |
 | nodeDriverRegistrar.resources | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
 | pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -20,6 +20,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | imagePullSecrets | list | `[]` |  |
 | kubeletPath | string | `"/var/lib/kubelet"` |  |
 | nameOverride | string | `""` |  |
@@ -28,6 +29,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
 | nodeDriverRegistrar.image.tag | string | `"v2.6.2"` | Overrides the image tag |
+| nodeDriverRegistrar.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | nodeDriverRegistrar.resources | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
 | pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -19,7 +19,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | kubeletPath | string | `"/var/lib/kubelet"` |  |
 | nameOverride | string | `""` |  |
@@ -27,7 +27,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
 | nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
-| nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
+| nodeDriverRegistrar.image.tag | string | `"v2.6.2"` |  |
 | nodeDriverRegistrar.resources | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
 | pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -8,6 +8,8 @@ image:
   repository: spiffe/spiffe-csi-driver
   # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+  version: ""
   # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 resources: {}
@@ -63,6 +65,8 @@ nodeDriverRegistrar:
     repository: sig-storage/csi-node-driver-registrar
     # -- The image pull policy
     pullPolicy: IfNotPresent
+    # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+    version: ""
     # -- Overrides the image tag
     tag: v2.6.2
   resources: {}

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -63,6 +63,7 @@ nodeDriverRegistrar:
     repository: sig-storage/csi-node-driver-registrar
     # -- The image pull policy
     pullPolicy: IfNotPresent
+    # -- Overrides the image tag
     tag: v2.6.2
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  version: ""
+  tag: ""
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -63,7 +63,7 @@ nodeDriverRegistrar:
     repository: sig-storage/csi-node-driver-registrar
     # -- The image pull policy
     pullPolicy: IfNotPresent
-    version: v2.6.2
+    tag: v2.6.2
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -47,7 +47,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
-| insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` |  |
+| insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` | Overrides the image tag |
 | insecureScheme.nginx.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
@@ -67,7 +67,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
-| telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` |  |
+| telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` | Overrides the image tag |
 | telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -34,7 +34,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -47,7 +47,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
-| insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
+| insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` |  |
 | insecureScheme.nginx.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
@@ -67,7 +67,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
-| telemetry.prometheus.nginxExporter.image.version | string | `"0.11.0"` |  |
+| telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` |  |
 | telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -35,6 +35,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -48,6 +49,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
 | insecureScheme.nginx.image.tag | string | `"1.23.2-alpine"` | Overrides the image tag |
+| insecureScheme.nginx.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | insecureScheme.nginx.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
@@ -68,6 +70,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
 | telemetry.prometheus.nginxExporter.image.tag | string | `"0.11.0"` | Overrides the image tag |
+| telemetry.prometheus.nginxExporter.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -16,6 +16,8 @@ image:
   repository: spiffe/oidc-discovery-provider
   # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+  version: ""
   # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 
@@ -65,6 +67,8 @@ insecureScheme:
       repository: nginxinc/nginx-unprivileged
       # -- The image pull policy
       pullPolicy: IfNotPresent
+      # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+      version: ""
       # -- Overrides the image tag
       tag: 1.23.2-alpine
       # chainguard image does not support the templates feature
@@ -147,6 +151,8 @@ telemetry:
         repository: nginx/nginx-prometheus-exporter
         # -- The image pull policy
         pullPolicy: IfNotPresent
+        # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+        version: ""
         # -- Overrides the image tag
         tag: "0.11.0"
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -65,6 +65,7 @@ insecureScheme:
       repository: nginxinc/nginx-unprivileged
       # -- The image pull policy
       pullPolicy: IfNotPresent
+      # -- Overrides the image tag
       tag: 1.23.2-alpine
       # chainguard image does not support the templates feature
       # https://github.com/chainguard-images/nginx/issues/43
@@ -146,6 +147,7 @@ telemetry:
         repository: nginx/nginx-prometheus-exporter
         # -- The image pull policy
         pullPolicy: IfNotPresent
+        # -- Overrides the image tag
         tag: "0.11.0"
 
       resources: {}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  version: ""
+  tag: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -65,13 +65,13 @@ insecureScheme:
       repository: nginxinc/nginx-unprivileged
       # -- The image pull policy
       pullPolicy: IfNotPresent
-      version: 1.23.2-alpine
+      tag: 1.23.2-alpine
       # chainguard image does not support the templates feature
       # https://github.com/chainguard-images/nginx/issues/43
       # registry: cgr.dev
       # repository: chainguard/nginx
       # pullPolicy: IfNotPresent
-      # version: "1.23.2"
+      # tag: "1.23.2"
     resources: {}
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little
@@ -146,7 +146,7 @@ telemetry:
         repository: nginx/nginx-prometheus-exporter
         # -- The image pull policy
         pullPolicy: IfNotPresent
-        version: "0.11.0"
+        tag: "0.11.0"
 
       resources: {}
         # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -26,6 +26,7 @@ A Helm chart to install the SPIRE agent.
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -55,7 +56,8 @@ A Helm chart to install the SPIRE agent.
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| waitForIt.image.tag | string | `"latest"` | Overrides the image tag |
+| waitForIt.image.tag | string | `"latest-20230517"` | Overrides the image tag |
+| waitForIt.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | waitForIt.resources | object | `{}` |  |
 | workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -25,7 +25,7 @@ A Helm chart to install the SPIRE agent.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
-| image.version | string | `""` |  |
+| image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -55,7 +55,7 @@ A Helm chart to install the SPIRE agent.
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| waitForIt.image.version | string | `"latest-20230113"` |  |
+| waitForIt.image.tag | string | `"latest-20230113"` |  |
 | waitForIt.resources | object | `{}` |  |
 | workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -25,7 +25,7 @@ A Helm chart to install the SPIRE agent.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
-| image.tag | string | `""` |  |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
@@ -55,7 +55,7 @@ A Helm chart to install the SPIRE agent.
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
-| waitForIt.image.tag | string | `"latest-20230113"` |  |
+| waitForIt.image.tag | string | `"latest"` | Overrides the image tag |
 | waitForIt.resources | object | `{}` |  |
 | workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
 | workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  version: ""
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -86,7 +86,7 @@ waitForIt:
     repository: chainguard/wait-for-it
     # -- The image pull policy
     pullPolicy: IfNotPresent
-    version: latest-20230113
+    tag: latest-20230113
   resources: {}
 
 # workloadAttestors determine a workload's properties and then generate a set of selectors associated with it.

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -9,6 +9,8 @@ image:
   repository: spiffe/spire-agent
   # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+  version: ""
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
@@ -86,8 +88,10 @@ waitForIt:
     repository: chainguard/wait-for-it
     # -- The image pull policy
     pullPolicy: IfNotPresent
+    # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+    version: ""
     # -- Overrides the image tag
-    tag: latest
+    tag: latest-20230517
   resources: {}
 
 # workloadAttestors determine a workload's properties and then generate a set of selectors associated with it.

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: spiffe/spire-agent
   # -- The image pull policy
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []
@@ -86,7 +86,8 @@ waitForIt:
     repository: chainguard/wait-for-it
     # -- The image pull policy
     pullPolicy: IfNotPresent
-    tag: latest-20230113
+    # -- Overrides the image tag
+    tag: latest
   resources: {}
 
 # workloadAttestors determine a workload's properties and then generate a set of selectors associated with it.

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -44,7 +44,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| controllerManager.image.tag | string | `"0.2.2"` |  |
+| controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
 | controllerManager.service.annotations | object | `{}` |  |
@@ -54,7 +54,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` | Overrides the image tag |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -44,7 +44,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| controllerManager.image.version | string | `"0.2.2"` |  |
+| controllerManager.image.tag | string | `"0.2.2"` |  |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
 | controllerManager.service.annotations | object | `{}` |  |
@@ -54,7 +54,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` |  |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -75,7 +75,7 @@ A Helm chart to install the SPIRE server.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -111,8 +111,9 @@ A Helm chart to install the SPIRE server.
 | topologySpreadConstraints | list | `[]` |  |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) |
-| tornjak.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"spiffe/tornjak-backend","version":"v1.2.0"}` | Tornjak API image |
-| tornjak.image.version | string | `"v1.2.0"` | Overrides the image tag whose default is the chart appVersion. |
+| tornjak.image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"spiffe/tornjak-backend","tag":"v1.2.0","version":""}` | Tornjak API image |
+| tornjak.image.tag | string | `"v1.2.0"` | Overrides the image tag |
+| tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak.resources | object | `{}` |  |
 | tornjak.service.annotations | object | `{}` |  |
 | tornjak.service.port | int | `10000` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -45,6 +45,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
+| controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
 | controllerManager.service.annotations | object | `{}` |  |
@@ -54,7 +55,8 @@ A Helm chart to install the SPIRE server.
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `"latest"` | Overrides the image tag |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `""` | Overrides the image tag |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -76,6 +78,7 @@ A Helm chart to install the SPIRE server.
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -107,8 +107,9 @@ Create the name of the service account to use
 
 {{- define "spire-server.kubectl-image" }}
 {{- $root := deepCopy . }}
-{{- if eq (len $root.image.version) 0 }}
-{{- $_ := set $root.image "version" $root.KubeVersion }}
+{{- $tag := (default $root.image.tag $root.image.version) | toString }}
+{{- if eq (len $tag) 0 }}
+{{- $_ := set $root.image "tag" $root.KubeVersion }}
 {{- end }}
 {{- include "spire-lib.image" $root }}
 {{- end }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -12,6 +12,8 @@ image:
   repository: spiffe/spire-server
   # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+  version: ""
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
@@ -169,6 +171,8 @@ controllerManager:
     repository: spiffe/spire-controller-manager
     # -- The image pull policy
     pullPolicy: IfNotPresent
+    # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+    version: ""
     # -- Overrides the image tag
     tag: "0.2.2"
 
@@ -229,8 +233,10 @@ controllerManager:
         repository: rancher/kubectl
         # -- The image pull policy
         pullPolicy: IfNotPresent
+        # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+        version: ""
         # -- Overrides the image tag
-        tag: latest
+        tag: ""
 
 telemetry:
   prometheus:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -273,8 +273,10 @@ tornjak:
     registry: ghcr.io
     repository: spiffe/tornjak-backend
     pullPolicy: IfNotPresent
-    # -- Overrides the image tag whose default is the chart appVersion.
-    version: "v1.2.0"
+    # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+    version: ""
+    # -- Overrides the image tag
+    tag: "v1.2.0"
   service:
     type: ClusterIP
     port: 10000

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  version: ""
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -170,7 +170,7 @@ controllerManager:
     # -- The image pull policy
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    version: "0.2.2"
+    tag: "0.2.2"
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -229,7 +229,7 @@ controllerManager:
         repository: rancher/kubectl
         # -- The image pull policy
         pullPolicy: IfNotPresent
-        version: ""
+        tag: latest
 
 telemetry:
   prometheus:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -169,7 +169,7 @@ controllerManager:
     repository: spiffe/spire-controller-manager
     # -- The image pull policy
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag
     tag: "0.2.2"
 
   resources: {}
@@ -229,6 +229,7 @@ controllerManager:
         repository: rancher/kubectl
         # -- The image pull policy
         pullPolicy: IfNotPresent
+        # -- Overrides the image tag
         tag: latest
 
 telemetry:

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -55,7 +55,8 @@ port forwarding. See the chart NOTES output for more details.
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"spiffe/tornjak-frontend"` |  |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | nameOverride | string | `""` |  |

--- a/charts/spire/charts/tornjak-frontend/values.yaml
+++ b/charts/spire/charts/tornjak-frontend/values.yaml
@@ -6,8 +6,10 @@ image:
   registry: ghcr.io
   repository: spiffe/tornjak-frontend
   pullPolicy: IfNotPresent
-  # -- Overrides the image tag whose default is the chart appVersion.
+  # -- This value is deprecated in favor of tag. (Will be removed in a future release)
   version: ""
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -40,12 +40,12 @@
 
 {{- define "spire-lib.image" -}}
 {{- $registry := include "spire-lib.registry" . }}
-{{- if eq (substr 0 7 .image.version) "sha256:" -}}
-{{- printf "%s/%s@%s" $registry .image.repository .image.version -}}
+{{- if eq (substr 0 7 .image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" $registry .image.repository .image.tag -}}
 {{- else if .appVersion -}}
-{{- printf "%s/%s:%s" $registry .image.repository (default .appVersion .image.version) -}}
-{{- else if .image.version -}}
-{{- printf "%s/%s:%s" $registry .image.repository .image.version -}}
+{{- printf "%s/%s:%s" $registry .image.repository (default .appVersion .image.tag) -}}
+{{- else if .image.tag -}}
+{{- printf "%s/%s:%s" $registry .image.repository .image.tag -}}
 {{- else -}}
 {{- printf "%s/%s" $registry .image.repository -}}
 {{- end -}}

--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -40,13 +40,15 @@
 
 {{- define "spire-lib.image" -}}
 {{- $registry := include "spire-lib.registry" . }}
-{{- if eq (substr 0 7 .image.tag) "sha256:" -}}
-{{- printf "%s/%s@%s" $registry .image.repository .image.tag -}}
-{{- else if .appVersion -}}
-{{- printf "%s/%s:%s" $registry .image.repository (default .appVersion .image.tag) -}}
-{{- else if .image.tag -}}
-{{- printf "%s/%s:%s" $registry .image.repository .image.tag -}}
-{{- else -}}
-{{- printf "%s/%s" $registry .image.repository -}}
-{{- end -}}
+{{- $repo := .image.repository }}
+{{- $tag := (default .image.tag .image.version) | toString }}
+{{- if eq (substr 0 7 $tag) "sha256:" }}
+{{- printf "%s/%s@%s" $registry $repo $tag }}
+{{- else if .appVersion }}
+{{- printf "%s/%s:%s" $registry $repo (default .appVersion $tag) }}
+{{- else if $tag }}
+{{- printf "%s/%s:%s" $registry $repo $tag }}
+{{- else }}
+{{- printf "%s/%s" $registry $repo }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The convention in most charts is to use image.tag. This pr updates the values to use it instead of the less standard image.version.