### PR TITLE
Use the correct kubectl for the cluster

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -289,9 +289,9 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` | The repository within the registry |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -50,9 +50,9 @@ A Helm chart to install the SPIRE server.
 | controllerManager.service.type | string | `"ClusterIP"` |  |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` |  |
 | dataStorage.accessMode | string | `"ReadWriteOnce"` |  |
 | dataStorage.enabled | bool | `true` |  |
 | dataStorage.size | string | `"1Gi"` |  |

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -105,3 +105,10 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "spire-server.kubectl-image" }}
+{{- $root := deepCopy . }}
+{{- if eq (len $root.image.version) 0 }}
+{{- $_ := set $root.image "version" $root.KubeVersion }}
+{{- end }}
+{{- include "spire-lib.image" $root }}
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -111,6 +111,7 @@ Create the name of the service account to use
 {{- $_ := set $root.image "version" $root.KubeVersion }}
 {{- end }}
 {{- include "spire-lib.image" $root }}
+{{- end }}
 
 {{- define "spire-server.config-mysql-query" }}
 {{- $lst := list }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -63,23 +63,25 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global) }}
-        command:
-        - /bin/sh
-        - -c
-        - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
-          {
-            "webhooks":[
-              {
-                "name":"vclusterspiffeid.kb.io",
-                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
-              },
-              {
-                "name":"vclusterfederatedtrustdomain.kb.io",
-                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
-              }
-            ]
-          }'
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        args:
+          - patch
+          - validatingwebhookconfiguration
+          - {{ include "spire-controller-manager.fullname" . }}-webhook
+          - --type=strategic
+          - -p
+          - |
+            {
+              "webhooks":[
+                {
+                  "name":"vclusterspiffeid.kb.io",
+                  "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+                },
+                {
+                  "name":"vclusterfederatedtrustdomain.kb.io",
+                  "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+                }
+              ]
+            }
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -63,23 +63,25 @@ spec:
       - name: post-upgrade-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global) }}
-        command:
-        - /bin/sh
-        - -c
-        - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
-          {
-            "webhooks":[
-              {
-                "name":"vclusterspiffeid.kb.io",
-                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
-              },
-              {
-                "name":"vclusterfederatedtrustdomain.kb.io",
-                "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
-              }
-            ]
-          }'
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        args:
+          - patch
+          - validatingwebhookconfiguration
+          - {{ include "spire-controller-manager.fullname" . }}-webhook
+          - --type=strategic
+          - -p
+          - |
+            {
+              "webhooks":[
+                {
+                  "name":"vclusterspiffeid.kb.io",
+                  "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+                },
+                {
+                  "name":"vclusterfederatedtrustdomain.kb.io",
+                  "failurePolicy":"{{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}"
+                }
+              ]
+            }
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -63,23 +63,25 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global) }}
-        command:
-        - /bin/sh
-        - -c
-        - |-
-          kubectl patch validatingwebhookconfiguration {{ include "spire-controller-manager.fullname" . }}-webhook --type='strategic' -p '
-          {
-            "webhooks":[
-              {
-                "name":"vclusterspiffeid.kb.io",
-                "failurePolicy":"Ignore"
-              },
-              {
-                "name":"vclusterfederatedtrustdomain.kb.io",
-                "failurePolicy":"Ignore"
-              }
-            ]
-          }'
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        args:
+          - patch
+          - validatingwebhookconfiguration
+          - {{ include "spire-controller-manager.fullname" . }}-webhook
+          - --type=strategic
+          - -p
+          - |
+            {
+              "webhooks":[
+                {
+                  "name":"vclusterspiffeid.kb.io",
+                  "failurePolicy":"Ignore"
+                },
+                {
+                  "name":"vclusterfederatedtrustdomain.kb.io",
+                  "failurePolicy":"Ignore"
+                }
+              ]
+            }
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -187,10 +187,10 @@ controllerManager:
     failurePolicy: Fail
     upgradeHook:
       image:
-        registry: cgr.dev
-        repository: chainguard/kubectl
+        registry: docker.io
+        repository: rancher/kubectl
         pullPolicy: IfNotPresent
-        version: latest
+        version: ""
 
 telemetry:
   prometheus:


### PR DESCRIPTION
This patch updates the hooks to use the correct version of kubectl for the cluster you are running on.

It also enables the hooks to run with a container image that does not contain a shell.

fixes: https://github.com/spiffe/helm-charts/issues/247