### PR TITLE
Allow trust bundle url to be set along with format

### DIFF
--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -48,8 +48,8 @@ A Helm chart to install the SPIRE agent.
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-agent |
 | telemetry.prometheus.port | int | `9988` |  |
-| trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are pem and spiffe. |
-| trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes configmap. |
+| trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
+| trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
 | trustDomain | string | `"example.org"` |  |
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
 | waitForIt.image.registry | string | `"cgr.dev"` |  |

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -48,6 +48,8 @@ A Helm chart to install the SPIRE agent.
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-agent |
 | telemetry.prometheus.port | int | `9988` |  |
+| trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are pem and spiffe. |
+| trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes configmap. |
 | trustDomain | string | `"example.org"` |  |
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
 | waitForIt.image.registry | string | `"cgr.dev"` |  |

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -5,7 +5,12 @@ agent:
   server_address: {{ include "spire-agent.server-address" . | trim | quote }}
   server_port: {{ .Values.server.port | quote }}
   socket_path: {{ include "spire-agent.socket-path" . | quote }}
+  {{- if ne (len .Values.trustBundleURL) 0 }}
+  trust_bundle_url: {{ .Values.trustBundleURL | quote }}
+  trust_bundle_format: {{ .Values.trustBundleFormat | quote }}
+  {{- else }}
   trust_bundle_path: "/run/spire/bundle/bundle.crt"
+  {{- end }}
   trust_domain: {{ include "spire-lib.trust-domain" . | quote }}
 
 plugins:

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -62,9 +62,11 @@ spec:
             - name: spire-config
               mountPath: /run/spire/config
               readOnly: true
+            {{- if eq (len .Values.trustBundleURL) 0 }}
             - name: spire-bundle
               mountPath: /run/spire/bundle
               readOnly: true
+            {{- end }}
             - name: spire-agent-socket-dir
               mountPath: {{ include "spire-agent.socket-path" . | dir }}
               readOnly: false
@@ -98,9 +100,11 @@ spec:
         - name: spire-config
           configMap:
             name: {{ include "spire-agent.fullname" . }}
+        {{- if eq (len .Values.trustBundleURL) 0 }}
         - name: spire-bundle
           configMap:
             name: {{ include "spire-lib.bundle-configmap" . }}
+        {{- end }}
         - name: spire-token
           projected:
             sources:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -55,7 +55,10 @@ nodeSelector: {}
 logLevel: info
 clusterName: example-cluster
 trustDomain: example.org
-
+# -- If set, obtain trust bundle from url instead of Kubernetes configmap.
+trustBundleURL: ""
+# -- If using trustBundleURL, what format is the url. Choices are pem and spiffe.
+trustBundleFormat: pem
 bundleConfigMap: spire-bundle
 
 server:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -55,9 +55,9 @@ nodeSelector: {}
 logLevel: info
 clusterName: example-cluster
 trustDomain: example.org
-# -- If set, obtain trust bundle from url instead of Kubernetes configmap.
+# -- If set, obtain trust bundle from url instead of Kubernetes ConfigMap
 trustBundleURL: ""
-# -- If using trustBundleURL, what format is the url. Choices are pem and spiffe.
+# -- If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe"
 trustBundleFormat: pem
 bundleConfigMap: spire-bundle
 


### PR DESCRIPTION
This patch enables the spire-agent to retrieve the trust bundle via url.

fixes: https://github.com/spiffe/helm-charts/issues/254
