### PR TITLE
Add project glossary.

### DIFF
--- a/project/glossary.md
+++ b/project/glossary.md
@@ -15,7 +15,7 @@ Deployment Type
 : One of three supported deployments of the template: Standalone, 
 Primary, or Secondary.
 
-Federation
+**Federation**
 : When one cluster is configured to trust elements of another cluster
 containing a different trust domain.
 

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -23,7 +23,7 @@ containing a different trust domain.
 : A Primary Deployment or Standalone Deployment that is configured
 to federate with one or more Deployments.
 
-Primary Deployment
+**Primary Deployment**
 : A deployment of the Helm Charts where the cluster's purpose is to
 provide certificates to Secondary Deployments.
 

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -36,7 +36,7 @@ Standalone Deployment
 : A deployment of the Helm Charts where the cluster both manages the CA
 and services Workload Identity requests in the same cluster.
 
-Tiered Deployment
+**Tiered Deployment**
 : Use of the Helm Charts two or more times, such that one chart is
 configured as a Primary Deployment Type and the others are configured as
 Secondary Deployment Types.

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -19,7 +19,7 @@ Primary, or Secondary.
 : When one cluster is configured to trust elements of another cluster
 containing a different trust domain.
 
-Federated Deployment
+**Federated Deployment**
 : A Primary Deployment or Standalone Deployment that is configured
 to federate with one or more Deployments.
 

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -11,7 +11,7 @@ team members.
 **Deployment**
 : A use of the Helm Charts to describe a single SPIRE cluster.
 
-Deployment Type
+**Deployment Type**
 : One of three supported deployments of the template: Standalone, 
 Primary, or Secondary.
 

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -12,7 +12,7 @@ team members.
 : A use of the Helm Charts to describe a single SPIRE cluster.
 
 **Deployment Type**
-: One of three supported deployments of the template: Standalone, 
+: One of three supported deployments of the charts: Standalone, 
 Primary, or Secondary.
 
 **Federation**

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -41,6 +41,6 @@ and services Workload Identity requests in the same cluster.
 configured as a Primary Deployment Type and the others are configured as
 Secondary Deployment Types.
 
-Trust Domain
+**Trust Domain**
 : The host field of a SPIFFE ID, naming a minimum footprint of a trust
 bundle's distribution.

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -27,7 +27,7 @@ to federate with one or more Deployments.
 : A deployment of the Helm Charts where the cluster's purpose is to
 provide certificates to Secondary Deployments.
 
-Secondary Deployment
+**Secondary Deployment**
 : A deployment of the Helm Charts where the cluster obtains an
 intermediate CA from a Primary Deployment and uses it to service
 Workload Identity requests.

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -32,7 +32,7 @@ provide certificates to Secondary Deployments.
 intermediate CA from a Primary Deployment and uses it to service
 Workload Identity requests.
 
-Standalone Deployment
+**Standalone Deployment**
 : A deployment of the Helm Charts where the cluster both manages the CA
 and services Workload Identity requests in the same cluster.
 

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -8,7 +8,7 @@ to keep other documents concise and precise.  Documenting terminology
 here helps prevent misundersandings, facilitating easy onboarding of new
 team members.
 
-Deployment
+**Deployment**
 : A use of the Helm Charts to describe a single SPIRE cluster.
 
 Deployment Type

--- a/project/glossary.md
+++ b/project/glossary.md
@@ -1,0 +1,46 @@
+<!-- vim: ft=markdown colorcolumn=72
+-->
+# Glossary
+
+This glossary is a dictionary of terms defined as they are used by the
+spire/helm-charts project.  Writing the definitions of terms here helps
+to keep other documents concise and precise.  Documenting terminology
+here helps prevent misundersandings, facilitating easy onboarding of new
+team members.
+
+Deployment
+: A use of the Helm Charts to describe a single SPIRE cluster.
+
+Deployment Type
+: One of three supported deployments of the template: Standalone, 
+Primary, or Secondary.
+
+Federation
+: When one cluster is configured to trust elements of another cluster
+containing a different trust domain.
+
+Federated Deployment
+: A Primary Deployment or Standalone Deployment that is configured
+to federate with one or more Deployments.
+
+Primary Deployment
+: A deployment of the Helm Charts where the cluster's purpose is to
+provide certificates to Secondary Deployments.
+
+Secondary Deployment
+: A deployment of the Helm Charts where the cluster obtains an
+intermediate CA from a Primary Deployment and uses it to service
+Workload Identity requests.
+
+Standalone Deployment
+: A deployment of the Helm Charts where the cluster both manages the CA
+and services Workload Identity requests in the same cluster.
+
+Tiered Deployment
+: Use of the Helm Charts two or more times, such that one chart is
+configured as a Primary Deployment Type and the others are configured as
+Secondary Deployment Types.
+
+Trust Domain
+: The host field of a SPIFFE ID, naming a minimum footprint of a trust
+bundle's distribution.

--- a/project/overview.md
+++ b/project/overview.md
@@ -42,6 +42,7 @@ The project is currently in a pre-release status.  While the standalone
 deployment is close to release quality, the tiered deployment is not.
 
 ## Project Navigation
+
 Below are links to project documentation useful for the management and
 maintenance of the spire/helm project.
 

--- a/project/overview.md
+++ b/project/overview.md
@@ -47,4 +47,5 @@ Below are links to project documentation useful for the management and
 maintenance of the spire/helm project.
 
 ### Coordination
+
 - [glossary](glossary.md)

--- a/project/overview.md
+++ b/project/overview.md
@@ -41,3 +41,9 @@ within the primary github repository.
 The project is currently in a pre-release status.  While the standalone
 deployment is close to release quality, the tiered deployment is not.
 
+## Project Navigation
+Below are links to project documentation useful for the management and
+maintenance of the spire/helm project.
+
+### Coordination
+- [glossary](glossary.md)


### PR DESCRIPTION
This glossary is not meant to be complete, as
no glossary can be.  It does mean to cover the
basic different deployments.

To keep things clear, federation was also added
to clarify that federation is not a deployment
but a different "thing".

Closes #261 