### PR TITLE
Allow for ConfigMaps to be annotated

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -29,6 +29,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | config.domains[0] | string | `"localhost"` |  |
 | config.domains[1] | string | `"oidc-discovery.example.org"` |  |
 | config.logLevel | string | `"info"` |  |
+| configMap.annotations | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -29,7 +29,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | config.domains[0] | string | `"localhost"` |  |
 | config.domains[1] | string | `"oidc-discovery.example.org"` |  |
 | config.logLevel | string | `"info"` |  |
-| configMap.annotations | object | `{}` |  |
+| configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
@@ -38,6 +38,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}
   namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   oidc-discovery-provider.conf: |
     {{- include "spiffe-oidc-discovery-provider.yaml-config" (dict "oidcSocket" $oidcSocket "root" .) | fromYaml | toPrettyJson | nindent 4 }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -34,6 +34,10 @@ service:
   annotations: {}
     # external-dns.alpha.kubernetes.io/hostname: oidc-discovery.example.org
 
+configMap:
+  # Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap
+  annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -35,7 +35,7 @@ service:
     # external-dns.alpha.kubernetes.io/hostname: oidc-discovery.example.org
 
 configMap:
-  # Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap
+  # -- Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap
   annotations: {}
 
 podSecurityContext: {}

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -16,7 +16,7 @@ A Helm chart to install the SPIRE agent.
 |-----|------|---------|-------------|
 | bundleConfigMap | string | `"spire-bundle"` |  |
 | clusterName | string | `"example-cluster"` |  |
-| configMap.annotations | object | `{}` |  |
+| configMap.annotations | object | `{}` | Annotations to add to the SPIRE Agent ConfigMap |
 | extraContainers | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -16,6 +16,7 @@ A Helm chart to install the SPIRE agent.
 |-----|------|---------|-------------|
 | bundleConfigMap | string | `"spire-bundle"` |  |
 | clusterName | string | `"example-cluster"` |  |
+| configMap.annotations | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -55,6 +55,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "spire-agent.fullname" . }}
   namespace: {{ include "spire-agent.namespace" . }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   agent.conf: |
     {{- include "spire-agent.yaml-config" . | fromYaml | toPrettyJson | nindent 4 }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -26,7 +26,7 @@ serviceAccount:
   name: ""
 
 configMap:
-  # Annotations to add to the SPIRE Agent ConfigMap
+  # -- Annotations to add to the SPIRE Agent ConfigMap
   annotations: {}
 
 podAnnotations: {}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -25,6 +25,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+configMap:
+  # Annotations to add to the SPIRE Agent ConfigMap
+  annotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -30,8 +30,8 @@ A Helm chart to install the SPIRE server.
 | ca_subject.organization | string | `"Example"` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | clusterName | string | `"example-cluster"` |  |
-| configMap.annotations | object | `{}` |  |
-| controllerManager.configMap.annotations | object | `{}` |  |
+| configMap.annotations | object | `{}` | Annotations to add to the SPIRE Server ConfigMap |
+| controllerManager.configMap.annotations | object | `{}` | Annotations to add to the Controller Manager ConfigMap |
 | controllerManager.enabled | bool | `false` |  |
 | controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | controllerManager.identities.enabled | bool | `true` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -30,6 +30,8 @@ A Helm chart to install the SPIRE server.
 | ca_subject.organization | string | `"Example"` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | clusterName | string | `"example-cluster"` |  |
+| configMap.annotations | object | `{}` |  |
+| controllerManager.configMap.annotations | object | `{}` |  |
 | controllerManager.enabled | bool | `false` |  |
 | controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | controllerManager.identities.enabled | bool | `true` |  |

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -104,6 +104,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "spire-server.fullname" . }}
   namespace: {{ include "spire-server.namespace" . }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   server.conf: |
     {{- include "spire-server.yaml-config" . | fromYaml | toPrettyJson | nindent 4 }}

--- a/charts/spire/charts/spire-server/templates/controller-manager-configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-configmap.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "spire-controller-manager.fullname" . }}
   namespace: {{ include "spire-server.namespace" . }}
+  {{- with .Values.controllerManager.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   controller-manager-config.yaml: |
     apiVersion: spire.spiffe.io/v1alpha1

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -191,7 +191,7 @@ controllerManager:
     annotations: {}
 
   configMap:
-    # Annotations to add to the Controller Manager ConfigMap
+    # -- Annotations to add to the Controller Manager ConfigMap
     annotations: {}
 
   ignoreNamespaces:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -46,6 +46,10 @@ service:
   port: 8081
   annotations: {}
 
+configMap:
+  # Annotations to add to the SPIRE Server ConfigMap
+  annotations: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -184,6 +188,10 @@ controllerManager:
   service:
     type: ClusterIP
     port: 443
+    annotations: {}
+
+  configMap:
+    # Annotations to add to the Controller Manager ConfigMap
     annotations: {}
 
   ignoreNamespaces:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -47,7 +47,7 @@ service:
   annotations: {}
 
 configMap:
-  # Annotations to add to the SPIRE Server ConfigMap
+  # -- Annotations to add to the SPIRE Server ConfigMap
   annotations: {}
 
 resources: {}


### PR DESCRIPTION
We use Spinnaker and without the annotation, spinnaker will rename the configmap.