### PR TITLE
Fix spacing for spire server service annotation

### DIFF
--- a/charts/spire/charts/spire-server/templates/service.yaml
+++ b/charts/spire/charts/spire-server/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "spire-server.namespace" . }}
   {{- with .Values.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}


### PR DESCRIPTION
Noticed the spacing for this was off.