### PR TITLE
Include dependency values in documentation

### DIFF
--- a/.github/tests/namespace-override/values.yaml
+++ b/.github/tests/namespace-override/values.yaml
@@ -21,6 +21,7 @@ spire-agent:
   enabled: true
   namespaceOverride: spire-system
   serviceAccount:
+    # -- The name of the service account to use.
     name: spire-agent
   server:
     namespaceOverride: spire-server

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -111,9 +111,9 @@ Kubernetes: `>=1.21.0-0`
 |-----|------|---------|-------------|
 | global.k8s.clusterDomain | string | `"cluster.local"` |  |
 | global.spire.bundleConfigMap | string | `""` | Override all instances of bundleConfigMap |
-| global.spire.clusterName | string | `"example-cluster"` | Set the name of the Kubernetes cluster |
+| global.spire.clusterName | string | `"example-cluster"` |  |
 | global.spire.image.registry | string | `""` | Override all Spire image registries at once |
-| global.spire.trustDomain | string | `"example.org"` | Set the trust domain to use for the spiffe identifiers |
+| global.spire.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 | spiffe-csi-driver.enabled | bool | `true` |  |
 | spiffe-oidc-discovery-provider.enabled | bool | `false` |  |
 | spire-agent.enabled | bool | `true` |  |
@@ -121,20 +121,20 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.enabled | bool | `true` |  |
 | spire-server.enabled | bool | `true` |  |
 | spire-server.nameOverride | string | `"server"` |  |
-| spiffe-csi-driver.agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| spiffe-csi-driver.agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` | The unix socket path to the spire-agent |
 | spiffe-csi-driver.fullnameOverride | string | `""` |  |
 | spiffe-csi-driver.healthChecks.port | int | `9809` |  |
-| spiffe-csi-driver.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spiffe-csi-driver.image.registry | string | `"ghcr.io"` |  |
-| spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` |  |
-| spiffe-csi-driver.image.version | string | `""` |  |
+| spiffe-csi-driver.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-csi-driver.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
+| spiffe-csi-driver.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | spiffe-csi-driver.imagePullSecrets | list | `[]` |  |
 | spiffe-csi-driver.kubeletPath | string | `"/var/lib/kubelet"` |  |
 | spiffe-csi-driver.nameOverride | string | `""` |  |
 | spiffe-csi-driver.namespaceOverride | string | `""` |  |
-| spiffe-csi-driver.nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` |  |
-| spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
+| spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
 | spiffe-csi-driver.nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
 | spiffe-csi-driver.nodeDriverRegistrar.resources | object | `{}` |  |
 | spiffe-csi-driver.nodeSelector | object | `{}` |  |
@@ -145,11 +145,11 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.resources | object | `{}` |  |
 | spiffe-csi-driver.securityContext.privileged | bool | `true` |  |
 | spiffe-csi-driver.securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| spiffe-csi-driver.serviceAccount.annotations | object | `{}` |  |
-| spiffe-csi-driver.serviceAccount.create | bool | `true` |  |
-| spiffe-csi-driver.serviceAccount.name | string | `""` |  |
+| spiffe-csi-driver.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| spiffe-csi-driver.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| spiffe-csi-driver.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | spiffe-oidc-discovery-provider.affinity | object | `{}` |  |
-| spiffe-oidc-discovery-provider.agentSocketName | string | `"spire-agent.sock"` |  |
+| spiffe-oidc-discovery-provider.agentSocketName | string | `"spire-agent.sock"` | The name of the spire-agent unix socket |
 | spiffe-oidc-discovery-provider.autoscaling.enabled | bool | `false` |  |
 | spiffe-oidc-discovery-provider.autoscaling.maxReplicas | int | `5` |  |
 | spiffe-oidc-discovery-provider.autoscaling.minReplicas | int | `1` |  |
@@ -162,13 +162,13 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.config.acme.tosAccepted | bool | `false` |  |
 | spiffe-oidc-discovery-provider.config.domains[0] | string | `"localhost"` |  |
 | spiffe-oidc-discovery-provider.config.domains[1] | string | `"oidc-discovery.example.org"` |  |
-| spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` |  |
+| spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` | The loglevel |
 | spiffe-oidc-discovery-provider.configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
 | spiffe-oidc-discovery-provider.fullnameOverride | string | `""` |  |
-| spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` |  |
-| spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` |  |
-| spiffe-oidc-discovery-provider.image.version | string | `""` |  |
+| spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
+| spiffe-oidc-discovery-provider.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | spiffe-oidc-discovery-provider.imagePullSecrets | list | `[]` |  |
 | spiffe-oidc-discovery-provider.ingress.annotations | object | `{}` |  |
 | spiffe-oidc-discovery-provider.ingress.className | string | `""` |  |
@@ -178,9 +178,9 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | spiffe-oidc-discovery-provider.ingress.tls | list | `[]` |  |
 | spiffe-oidc-discovery-provider.insecureScheme.enabled | bool | `false` |  |
-| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` |  |
-| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.nameOverride | string | `""` |  |
@@ -194,13 +194,13 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.service.annotations | object | `{}` |  |
 | spiffe-oidc-discovery-provider.service.port | int | `80` |  |
 | spiffe-oidc-discovery-provider.service.type | string | `"ClusterIP"` |  |
-| spiffe-oidc-discovery-provider.serviceAccount.annotations | object | `{}` |  |
-| spiffe-oidc-discovery-provider.serviceAccount.create | bool | `true` |  |
-| spiffe-oidc-discovery-provider.serviceAccount.name | string | `""` |  |
+| spiffe-oidc-discovery-provider.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| spiffe-oidc-discovery-provider.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| spiffe-oidc-discovery-provider.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.enabled | bool | `false` |  |
-| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` |  |
-| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.version | string | `"0.11.0"` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
@@ -208,7 +208,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spiffe-oidc-discovery-provider |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.port | int | `9988` |  |
 | spiffe-oidc-discovery-provider.tolerations | list | `[]` |  |
-| spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` |  |
+| spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 | spire-agent.bundleConfigMap | string | `"spire-bundle"` |  |
 | spire-agent.clusterName | string | `"example-cluster"` |  |
 | spire-agent.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Agent ConfigMap |
@@ -217,13 +217,13 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.extraVolumes | list | `[]` |  |
 | spire-agent.fullnameOverride | string | `""` |  |
 | spire-agent.healthChecks.port | int | `9980` | override the host port used for health checking |
-| spire-agent.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spire-agent.image.registry | string | `"ghcr.io"` |  |
-| spire-agent.image.repository | string | `"spiffe/spire-agent"` |  |
+| spire-agent.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-agent.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| spire-agent.image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
 | spire-agent.image.version | string | `""` |  |
 | spire-agent.imagePullSecrets | list | `[]` |  |
 | spire-agent.initContainers | list | `[]` |  |
-| spire-agent.logLevel | string | `"info"` |  |
+| spire-agent.logLevel | string | `"info"` | The loglevel |
 | spire-agent.nameOverride | string | `""` |  |
 | spire-agent.namespaceOverride | string | `""` |  |
 | spire-agent.nodeSelector | object | `{}` |  |
@@ -235,10 +235,10 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.server.address | string | `""` |  |
 | spire-agent.server.namespaceOverride | string | `""` |  |
 | spire-agent.server.port | int | `8081` |  |
-| spire-agent.serviceAccount.annotations | object | `{}` |  |
-| spire-agent.serviceAccount.create | bool | `true` |  |
-| spire-agent.serviceAccount.name | string | `""` |  |
-| spire-agent.socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| spire-agent.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| spire-agent.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| spire-agent.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| spire-agent.socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` | The unix socket path to the spire-agent |
 | spire-agent.telemetry.prometheus.enabled | bool | `false` |  |
 | spire-agent.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | spire-agent.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
@@ -246,10 +246,10 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.telemetry.prometheus.port | int | `9988` |  |
 | spire-agent.trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | spire-agent.trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
-| spire-agent.trustDomain | string | `"example.org"` |  |
-| spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spire-agent.waitForIt.image.registry | string | `"cgr.dev"` |  |
-| spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` |  |
+| spire-agent.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-agent.waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
+| spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
 | spire-agent.waitForIt.image.version | string | `"latest-20230113"` |  |
 | spire-agent.waitForIt.resources | object | `{}` |  |
 | spire-agent.workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
@@ -278,9 +278,9 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.ignoreNamespaces[0] | string | `"kube-system"` |  |
 | spire-server.controllerManager.ignoreNamespaces[1] | string | `"kube-public"` |  |
 | spire-server.controllerManager.ignoreNamespaces[2] | string | `"local-path-storage"` |  |
-| spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spire-server.controllerManager.image.registry | string | `"ghcr.io"` |  |
-| spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` |  |
+| spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-server.controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | spire-server.controllerManager.image.version | string | `"0.2.2"` |  |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |
@@ -288,9 +288,9 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.service.port | int | `443` |  |
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` |  |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` | The repository within the registry |
 | spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
@@ -309,14 +309,14 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.federation.bundleEndpoint.port | int | `8443` |  |
 | spire-server.federation.enabled | bool | `false` |  |
 | spire-server.fullnameOverride | string | `""` |  |
-| spire-server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| spire-server.image.registry | string | `"ghcr.io"` |  |
-| spire-server.image.repository | string | `"spiffe/spire-server"` |  |
+| spire-server.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-server.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| spire-server.image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
 | spire-server.image.version | string | `""` |  |
 | spire-server.imagePullSecrets | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
-| spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` |  |
-| spire-server.logLevel | string | `"info"` |  |
+| spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |
+| spire-server.logLevel | string | `"info"` | The loglevel |
 | spire-server.nameOverride | string | `""` |  |
 | spire-server.namespaceOverride | string | `""` |  |
 | spire-server.nodeAttestor.k8sPsat.enabled | bool | `true` |  |
@@ -334,16 +334,16 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.service.annotations | object | `{}` |  |
 | spire-server.service.port | int | `8081` |  |
 | spire-server.service.type | string | `"ClusterIP"` |  |
-| spire-server.serviceAccount.annotations | object | `{}` |  |
-| spire-server.serviceAccount.create | bool | `true` |  |
-| spire-server.serviceAccount.name | string | `""` |  |
+| spire-server.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| spire-server.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| spire-server.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | spire-server.telemetry.prometheus.enabled | bool | `false` |  |
 | spire-server.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | spire-server.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | spire-server.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-server |
 | spire-server.tolerations | list | `[]` |  |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
-| spire-server.trustDomain | string | `"example.org"` |  |
+| spire-server.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 | spire-server.upstreamAuthority.certManager.enabled | bool | `false` |  |
 | spire-server.upstreamAuthority.certManager.issuer_group | string | `"cert-manager.io"` |  |
 | spire-server.upstreamAuthority.certManager.issuer_kind | string | `"Issuer"` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -121,5 +121,239 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.controllerManager.enabled | bool | `true` |  |
 | spire-server.enabled | bool | `true` |  |
 | spire-server.nameOverride | string | `"server"` |  |
+| spiffe-csi-driver.agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| spiffe-csi-driver.fullnameOverride | string | `""` |  |
+| spiffe-csi-driver.healthChecks.port | int | `9809` |  |
+| spiffe-csi-driver.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spiffe-csi-driver.image.registry | string | `"ghcr.io"` |  |
+| spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` |  |
+| spiffe-csi-driver.image.version | string | `""` |  |
+| spiffe-csi-driver.imagePullSecrets | list | `[]` |  |
+| spiffe-csi-driver.kubeletPath | string | `"/var/lib/kubelet"` |  |
+| spiffe-csi-driver.nameOverride | string | `""` |  |
+| spiffe-csi-driver.namespaceOverride | string | `""` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
+| spiffe-csi-driver.nodeDriverRegistrar.resources | object | `{}` |  |
+| spiffe-csi-driver.nodeSelector | object | `{}` |  |
+| spiffe-csi-driver.pluginName | string | `"csi.spiffe.io"` | Set the csi driver name deployed to Kubernetes. |
+| spiffe-csi-driver.podAnnotations | object | `{}` |  |
+| spiffe-csi-driver.podSecurityContext | object | `{}` |  |
+| spiffe-csi-driver.priorityClassName | string | `""` | Priority class assigned to daemonset pods |
+| spiffe-csi-driver.resources | object | `{}` |  |
+| spiffe-csi-driver.securityContext.privileged | bool | `true` |  |
+| spiffe-csi-driver.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| spiffe-csi-driver.serviceAccount.annotations | object | `{}` |  |
+| spiffe-csi-driver.serviceAccount.create | bool | `true` |  |
+| spiffe-csi-driver.serviceAccount.name | string | `""` |  |
+| spiffe-oidc-discovery-provider.affinity | object | `{}` |  |
+| spiffe-oidc-discovery-provider.agentSocketName | string | `"spire-agent.sock"` |  |
+| spiffe-oidc-discovery-provider.autoscaling.enabled | bool | `false` |  |
+| spiffe-oidc-discovery-provider.autoscaling.maxReplicas | int | `5` |  |
+| spiffe-oidc-discovery-provider.autoscaling.minReplicas | int | `1` |  |
+| spiffe-oidc-discovery-provider.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| spiffe-oidc-discovery-provider.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| spiffe-oidc-discovery-provider.clusterDomain | string | `"cluster.local"` |  |
+| spiffe-oidc-discovery-provider.config.acme.cacheDir | string | `"/run/spire"` |  |
+| spiffe-oidc-discovery-provider.config.acme.directoryUrl | string | `"https://acme-v02.api.letsencrypt.org/directory"` |  |
+| spiffe-oidc-discovery-provider.config.acme.emailAddress | string | `"letsencrypt@example.org"` |  |
+| spiffe-oidc-discovery-provider.config.acme.tosAccepted | bool | `false` |  |
+| spiffe-oidc-discovery-provider.config.domains[0] | string | `"localhost"` |  |
+| spiffe-oidc-discovery-provider.config.domains[1] | string | `"oidc-discovery.example.org"` |  |
+| spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` |  |
+| spiffe-oidc-discovery-provider.configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
+| spiffe-oidc-discovery-provider.fullnameOverride | string | `""` |  |
+| spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` |  |
+| spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` |  |
+| spiffe-oidc-discovery-provider.image.version | string | `""` |  |
+| spiffe-oidc-discovery-provider.imagePullSecrets | list | `[]` |  |
+| spiffe-oidc-discovery-provider.ingress.annotations | object | `{}` |  |
+| spiffe-oidc-discovery-provider.ingress.className | string | `""` |  |
+| spiffe-oidc-discovery-provider.ingress.enabled | bool | `false` |  |
+| spiffe-oidc-discovery-provider.ingress.hosts[0].host | string | `"oidc-discovery.example.org"` |  |
+| spiffe-oidc-discovery-provider.ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| spiffe-oidc-discovery-provider.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| spiffe-oidc-discovery-provider.ingress.tls | list | `[]` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.enabled | bool | `false` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.registry | string | `"docker.io"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
+| spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
+| spiffe-oidc-discovery-provider.nameOverride | string | `""` |  |
+| spiffe-oidc-discovery-provider.namespaceOverride | string | `""` |  |
+| spiffe-oidc-discovery-provider.nodeSelector | object | `{}` |  |
+| spiffe-oidc-discovery-provider.podAnnotations | object | `{}` |  |
+| spiffe-oidc-discovery-provider.podSecurityContext | object | `{}` |  |
+| spiffe-oidc-discovery-provider.replicaCount | int | `1` |  |
+| spiffe-oidc-discovery-provider.resources | object | `{}` |  |
+| spiffe-oidc-discovery-provider.securityContext | object | `{}` |  |
+| spiffe-oidc-discovery-provider.service.annotations | object | `{}` |  |
+| spiffe-oidc-discovery-provider.service.port | int | `80` |  |
+| spiffe-oidc-discovery-provider.service.type | string | `"ClusterIP"` |  |
+| spiffe-oidc-discovery-provider.serviceAccount.annotations | object | `{}` |  |
+| spiffe-oidc-discovery-provider.serviceAccount.create | bool | `true` |  |
+| spiffe-oidc-discovery-provider.serviceAccount.name | string | `""` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.enabled | bool | `false` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.image.version | string | `"0.11.0"` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spiffe-oidc-discovery-provider |
+| spiffe-oidc-discovery-provider.telemetry.prometheus.port | int | `9988` |  |
+| spiffe-oidc-discovery-provider.tolerations | list | `[]` |  |
+| spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` |  |
+| spire-agent.bundleConfigMap | string | `"spire-bundle"` |  |
+| spire-agent.clusterName | string | `"example-cluster"` |  |
+| spire-agent.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Agent ConfigMap |
+| spire-agent.extraContainers | list | `[]` |  |
+| spire-agent.extraVolumeMounts | list | `[]` |  |
+| spire-agent.extraVolumes | list | `[]` |  |
+| spire-agent.fullnameOverride | string | `""` |  |
+| spire-agent.healthChecks.port | int | `9980` | override the host port used for health checking |
+| spire-agent.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spire-agent.image.registry | string | `"ghcr.io"` |  |
+| spire-agent.image.repository | string | `"spiffe/spire-agent"` |  |
+| spire-agent.image.version | string | `""` |  |
+| spire-agent.imagePullSecrets | list | `[]` |  |
+| spire-agent.initContainers | list | `[]` |  |
+| spire-agent.logLevel | string | `"info"` |  |
+| spire-agent.nameOverride | string | `""` |  |
+| spire-agent.namespaceOverride | string | `""` |  |
+| spire-agent.nodeSelector | object | `{}` |  |
+| spire-agent.podAnnotations | object | `{}` |  |
+| spire-agent.podSecurityContext | object | `{}` |  |
+| spire-agent.priorityClassName | string | `""` | Priority class assigned to daemonset pods |
+| spire-agent.resources | object | `{}` |  |
+| spire-agent.securityContext | object | `{}` |  |
+| spire-agent.server.address | string | `""` |  |
+| spire-agent.server.namespaceOverride | string | `""` |  |
+| spire-agent.server.port | int | `8081` |  |
+| spire-agent.serviceAccount.annotations | object | `{}` |  |
+| spire-agent.serviceAccount.create | bool | `true` |  |
+| spire-agent.serviceAccount.name | string | `""` |  |
+| spire-agent.socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| spire-agent.telemetry.prometheus.enabled | bool | `false` |  |
+| spire-agent.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
+| spire-agent.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
+| spire-agent.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-agent |
+| spire-agent.telemetry.prometheus.port | int | `9988` |  |
+| spire-agent.trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
+| spire-agent.trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
+| spire-agent.trustDomain | string | `"example.org"` |  |
+| spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spire-agent.waitForIt.image.registry | string | `"cgr.dev"` |  |
+| spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` |  |
+| spire-agent.waitForIt.image.version | string | `"latest-20230113"` |  |
+| spire-agent.waitForIt.resources | object | `{}` |  |
+| spire-agent.workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |
+| spire-agent.workloadAttestors.unix.enabled | bool | `false` | enables the Unix workload attestor |
+| spire-server.affinity | object | `{}` |  |
+| spire-server.autoscaling.enabled | bool | `false` |  |
+| spire-server.autoscaling.maxReplicas | int | `100` |  |
+| spire-server.autoscaling.minReplicas | int | `1` |  |
+| spire-server.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| spire-server.bundleConfigMap | string | `"spire-bundle"` |  |
+| spire-server.caKeyType | string | `"rsa-2048"` | The CA key type to use, possible values are rsa-2048, rsa-4096, ec-p256, ec-p384 (AWS requires the use of RSA.  EC cryptography is not supported) |
+| spire-server.caTTL | string | `"24h"` |  |
+| spire-server.ca_subject.common_name | string | `"example.org"` |  |
+| spire-server.ca_subject.country | string | `"NL"` |  |
+| spire-server.ca_subject.organization | string | `"Example"` |  |
+| spire-server.clusterDomain | string | `"cluster.local"` |  |
+| spire-server.clusterName | string | `"example-cluster"` |  |
+| spire-server.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Server ConfigMap |
+| spire-server.controllerManager.configMap.annotations | object | `{}` | Annotations to add to the Controller Manager ConfigMap |
+| spire-server.controllerManager.enabled | bool | `false` |  |
+| spire-server.controllerManager.identities.dnsNameTemplates | list | `[]` |  |
+| spire-server.controllerManager.identities.enabled | bool | `true` |  |
+| spire-server.controllerManager.identities.namespaceSelector | object | `{}` |  |
+| spire-server.controllerManager.identities.podSelector | object | `{}` |  |
+| spire-server.controllerManager.identities.spiffeIDTemplate | string | `"spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"` |  |
+| spire-server.controllerManager.ignoreNamespaces[0] | string | `"kube-system"` |  |
+| spire-server.controllerManager.ignoreNamespaces[1] | string | `"kube-public"` |  |
+| spire-server.controllerManager.ignoreNamespaces[2] | string | `"local-path-storage"` |  |
+| spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spire-server.controllerManager.image.registry | string | `"ghcr.io"` |  |
+| spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` |  |
+| spire-server.controllerManager.image.version | string | `"0.2.2"` |  |
+| spire-server.controllerManager.resources | object | `{}` |  |
+| spire-server.controllerManager.securityContext | object | `{}` |  |
+| spire-server.controllerManager.service.annotations | object | `{}` |  |
+| spire-server.controllerManager.service.port | int | `443` |  |
+| spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` |  |
+| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
+| spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
+| spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
+| spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
+| spire-server.dataStore.sql.options | list | `[]` | Only used by "postgres" or "mysql" |
+| spire-server.dataStore.sql.password | string | `""` | Only used by "postgres" or "mysql" |
+| spire-server.dataStore.sql.plugin_data | object | `{}` | Settings from https://github.com/spiffe/spire/blob/main/doc/plugin_server_datastore_sql.md go in this section |
+| spire-server.dataStore.sql.port | int | `0` | If 0 (default), it will auto set to 5432 for postgres and 3306 for mysql. Only used by those databases. |
+| spire-server.dataStore.sql.username | string | `"spire"` | Only used by "postgres" or "mysql" |
+| spire-server.defaultJwtSvidTTL | string | `"1h"` |  |
+| spire-server.defaultX509SvidTTL | string | `"4h"` |  |
+| spire-server.extraContainers | list | `[]` |  |
+| spire-server.extraVolumeMounts | list | `[]` |  |
+| spire-server.extraVolumes | list | `[]` |  |
+| spire-server.federation.bundleEndpoint.address | string | `"0.0.0.0"` |  |
+| spire-server.federation.bundleEndpoint.port | int | `8443` |  |
+| spire-server.federation.enabled | bool | `false` |  |
+| spire-server.fullnameOverride | string | `""` |  |
+| spire-server.image.pullPolicy | string | `"IfNotPresent"` |  |
+| spire-server.image.registry | string | `"ghcr.io"` |  |
+| spire-server.image.repository | string | `"spiffe/spire-server"` |  |
+| spire-server.image.version | string | `""` |  |
+| spire-server.imagePullSecrets | list | `[]` |  |
+| spire-server.initContainers | list | `[]` |  |
+| spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` |  |
+| spire-server.logLevel | string | `"info"` |  |
+| spire-server.nameOverride | string | `""` |  |
+| spire-server.namespaceOverride | string | `""` |  |
+| spire-server.nodeAttestor.k8sPsat.enabled | bool | `true` |  |
+| spire-server.nodeAttestor.k8sPsat.serviceAccountAllowList | list | `[]` |  |
+| spire-server.nodeSelector | object | `{}` |  |
+| spire-server.notifier.k8sbundle.namespace | string | `""` | Namespace to push the bundle into, if blank will default to SPIRE Server namespace |
+| spire-server.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| spire-server.persistence.size | string | `"1Gi"` |  |
+| spire-server.persistence.storageClass | string | `nil` |  |
+| spire-server.podAnnotations | object | `{}` |  |
+| spire-server.podSecurityContext | object | `{}` |  |
+| spire-server.replicaCount | int | `1` | SPIRE server currently runs with a sqlite database. Scaling to multiple instances will not work until we use an external database. |
+| spire-server.resources | object | `{}` |  |
+| spire-server.securityContext | object | `{}` |  |
+| spire-server.service.annotations | object | `{}` |  |
+| spire-server.service.port | int | `8081` |  |
+| spire-server.service.type | string | `"ClusterIP"` |  |
+| spire-server.serviceAccount.annotations | object | `{}` |  |
+| spire-server.serviceAccount.create | bool | `true` |  |
+| spire-server.serviceAccount.name | string | `""` |  |
+| spire-server.telemetry.prometheus.enabled | bool | `false` |  |
+| spire-server.telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
+| spire-server.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
+| spire-server.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-server |
+| spire-server.tolerations | list | `[]` |  |
+| spire-server.topologySpreadConstraints | list | `[]` |  |
+| spire-server.trustDomain | string | `"example.org"` |  |
+| spire-server.upstreamAuthority.certManager.enabled | bool | `false` |  |
+| spire-server.upstreamAuthority.certManager.issuer_group | string | `"cert-manager.io"` |  |
+| spire-server.upstreamAuthority.certManager.issuer_kind | string | `"Issuer"` |  |
+| spire-server.upstreamAuthority.certManager.issuer_name | string | `"spire-ca"` |  |
+| spire-server.upstreamAuthority.certManager.kube_config_file | string | `""` |  |
+| spire-server.upstreamAuthority.certManager.namespace | string | `""` | Specify to use a namespace other then the one the chart is installed into |
+| spire-server.upstreamAuthority.certManager.rbac.create | bool | `true` |  |
+| spire-server.upstreamAuthority.disk.enabled | bool | `false` |  |
+| spire-server.upstreamAuthority.disk.secret.create | bool | `true` | If disabled requires you to create a secret with the given keys (certificate, key and optional bundle) yourself. |
+| spire-server.upstreamAuthority.disk.secret.data | object | `{"bundle":"","certificate":"","key":""}` | If secret creation is enabled, will create a secret with following certificate info |
+| spire-server.upstreamAuthority.disk.secret.name | string | `"spiffe-upstream-ca"` | If secret creation is disabled, the secret with this name will be used. |
 
 ----------------------------------------------

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -113,7 +113,7 @@ Kubernetes: `>=1.21.0-0`
 | global.spire.bundleConfigMap | string | `""` | Override all instances of bundleConfigMap |
 | global.spire.clusterName | string | `"example-cluster"` |  |
 | global.spire.image.registry | string | `""` | Override all Spire image registries at once |
-| global.spire.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| global.spire.trustDomain | string | `"example.org"` | The trust domain to be used for the SPIFFE identifiers |
 | spiffe-csi-driver.enabled | bool | `true` |  |
 | spiffe-oidc-discovery-provider.enabled | bool | `false` |  |
 | spire-agent.enabled | bool | `true` |  |
@@ -127,7 +127,7 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-csi-driver.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-csi-driver.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-csi-driver.image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
-| spiffe-csi-driver.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| spiffe-csi-driver.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | spiffe-csi-driver.imagePullSecrets | list | `[]` |  |
 | spiffe-csi-driver.kubeletPath | string | `"/var/lib/kubelet"` |  |
 | spiffe-csi-driver.nameOverride | string | `""` |  |
@@ -162,13 +162,13 @@ Kubernetes: `>=1.21.0-0`
 | spiffe-oidc-discovery-provider.config.acme.tosAccepted | bool | `false` |  |
 | spiffe-oidc-discovery-provider.config.domains[0] | string | `"localhost"` |  |
 | spiffe-oidc-discovery-provider.config.domains[1] | string | `"oidc-discovery.example.org"` |  |
-| spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` | The loglevel |
+| spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | spiffe-oidc-discovery-provider.configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
 | spiffe-oidc-discovery-provider.fullnameOverride | string | `""` |  |
 | spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spiffe-oidc-discovery-provider.image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
-| spiffe-oidc-discovery-provider.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| spiffe-oidc-discovery-provider.image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | spiffe-oidc-discovery-provider.imagePullSecrets | list | `[]` |  |
 | spiffe-oidc-discovery-provider.ingress.annotations | object | `{}` |  |
 | spiffe-oidc-discovery-provider.ingress.className | string | `""` |  |
@@ -223,7 +223,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.image.version | string | `""` |  |
 | spire-agent.imagePullSecrets | list | `[]` |  |
 | spire-agent.initContainers | list | `[]` |  |
-| spire-agent.logLevel | string | `"info"` | The loglevel |
+| spire-agent.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | spire-agent.nameOverride | string | `""` |  |
 | spire-agent.namespaceOverride | string | `""` |  |
 | spire-agent.nodeSelector | object | `{}` |  |
@@ -246,7 +246,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-agent.telemetry.prometheus.port | int | `9988` |  |
 | spire-agent.trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | spire-agent.trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
-| spire-agent.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| spire-agent.trustDomain | string | `"example.org"` | The trust domain to be used for the SPIFFE identifiers |
 | spire-agent.waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-agent.waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | spire-agent.waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
@@ -316,7 +316,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.imagePullSecrets | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
 | spire-server.jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |
-| spire-server.logLevel | string | `"info"` | The loglevel |
+| spire-server.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | spire-server.nameOverride | string | `""` |  |
 | spire-server.namespaceOverride | string | `""` |  |
 | spire-server.nodeAttestor.k8sPsat.enabled | bool | `true` |  |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -19,7 +19,7 @@ A Helm chart to install the SPIFFE CSI driver.
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | kubeletPath | string | `"/var/lib/kubelet"` |  |
 | nameOverride | string | `""` |  |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -13,20 +13,20 @@ A Helm chart to install the SPIFFE CSI driver.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| agentSocketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` | The unix socket path to the spire-agent |
 | fullnameOverride | string | `""` |  |
 | healthChecks.port | int | `9809` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"spiffe/spiffe-csi-driver"` |  |
-| image.version | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| image.repository | string | `"spiffe/spiffe-csi-driver"` | The repository within the registry |
+| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | kubeletPath | string | `"/var/lib/kubelet"` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
-| nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` |  |
-| nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` |  |
-| nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` |  |
+| nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` | The OCI registry to pull the image from |
+| nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | The repository within the registry |
 | nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
 | nodeDriverRegistrar.resources | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
@@ -37,8 +37,8 @@ A Helm chart to install the SPIFFE CSI driver.
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -2,9 +2,13 @@
 pluginName: csi.spiffe.io
 
 image:
+  # -- The OCI registry to pull the image from
   registry: ghcr.io
+  # -- The repository within the registry
   repository: spiffe/spiffe-csi-driver
+  # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
   version: ""
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -27,11 +31,11 @@ namespaceOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
@@ -53,8 +57,11 @@ nodeSelector: {}
 
 nodeDriverRegistrar:
   image:
+    # -- The OCI registry to pull the image from
     registry: registry.k8s.io
+    # -- The repository within the registry
     repository: sig-storage/csi-node-driver-registrar
+    # -- The image pull policy
     pullPolicy: IfNotPresent
     version: v2.6.2
   resources: {}
@@ -69,6 +76,7 @@ nodeDriverRegistrar:
     #   cpu: 100m
     #   memory: 64Mi
 
+# -- The unix socket path to the spire-agent
 agentSocketPath: /run/spire/agent-sockets/spire-agent.sock
 
 kubeletPath: /var/lib/kubelet

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: spiffe/spiffe-csi-driver
   # -- The image pull policy
   pullPolicy: IfNotPresent
-  # -- Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion
   version: ""
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -15,7 +15,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| agentSocketName | string | `"spire-agent.sock"` |  |
+| agentSocketName | string | `"spire-agent.sock"` | The name of the spire-agent unix socket |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `5` |  |
 | autoscaling.minReplicas | int | `1` |  |
@@ -28,13 +28,13 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | config.acme.tosAccepted | bool | `false` |  |
 | config.domains[0] | string | `"localhost"` |  |
 | config.domains[1] | string | `"oidc-discovery.example.org"` |  |
-| config.logLevel | string | `"info"` |  |
+| config.logLevel | string | `"info"` | The loglevel |
 | configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"spiffe/oidc-discovery-provider"` |  |
-| image.version | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
+| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -44,9 +44,9 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | insecureScheme.enabled | bool | `false` |  |
-| insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
-| insecureScheme.nginx.image.registry | string | `"docker.io"` |  |
-| insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
+| insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| insecureScheme.nginx.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| insecureScheme.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` | The repository within the registry |
 | insecureScheme.nginx.image.version | string | `"1.23.2-alpine"` |  |
 | insecureScheme.nginx.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
@@ -60,13 +60,13 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | service.annotations | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | telemetry.prometheus.enabled | bool | `false` |  |
-| telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` |  |
-| telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` |  |
-| telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` |  |
+| telemetry.prometheus.nginxExporter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| telemetry.prometheus.nginxExporter.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| telemetry.prometheus.nginxExporter.image.repository | string | `"nginx/nginx-prometheus-exporter"` | The repository within the registry |
 | telemetry.prometheus.nginxExporter.image.version | string | `"0.11.0"` |  |
 | telemetry.prometheus.nginxExporter.resources | object | `{}` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
@@ -74,6 +74,6 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spiffe-oidc-discovery-provider |
 | telemetry.prometheus.port | int | `9988` |  |
 | tolerations | list | `[]` |  |
-| trustDomain | string | `"example.org"` |  |
+| trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -28,13 +28,13 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | config.acme.tosAccepted | bool | `false` |  |
 | config.domains[0] | string | `"localhost"` |  |
 | config.domains[1] | string | `"oidc-discovery.example.org"` |  |
-| config.logLevel | string | `"info"` | The loglevel |
+| config.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spiffe/oidc-discovery-provider"` | The repository within the registry |
-| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.version | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -9,8 +9,6 @@ replicaCount: 1
 namespaceOverride: ""
 
 image:
-  # registry: gcr.io
-  # repository: spiffe-io/oidc-discovery-provider
   registry: ghcr.io
   repository: spiffe/oidc-discovery-provider
   pullPolicy: IfNotPresent

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: spiffe/oidc-discovery-provider
   # -- The image pull policy
   pullPolicy: IfNotPresent
-  # -- Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion
   version: ""
 
 resources: {}
@@ -85,7 +85,7 @@ insecureScheme:
       #   memory: 64Mi
 
 config:
-  # -- The loglevel
+  # -- The log level, valid values are "debug", "info", "warn", and "error"
   logLevel: info
   domains:
     - localhost
@@ -125,7 +125,7 @@ affinity: {}
 
 # -- Set the trust domain to be used for the SPIFFE identifiers
 trustDomain: example.org
-# -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
+# -- The name of the Kubernetes cluster (`kubeadm init --service-dns-domain`)
 clusterDomain: cluster.local
 
 telemetry:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- The name of the spire-agent unix socket
 agentSocketName: spire-agent.sock
 
 replicaCount: 1
@@ -9,9 +10,13 @@ replicaCount: 1
 namespaceOverride: ""
 
 image:
+  # -- The OCI registry to pull the image from
   registry: ghcr.io
+  # -- The repository within the registry
   repository: spiffe/oidc-discovery-provider
+  # -- The image pull policy
   pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
   version: ""
 
 resources: {}
@@ -54,8 +59,11 @@ insecureScheme:
 
   nginx:
     image:
+      # -- The OCI registry to pull the image from
       registry: docker.io
+      # -- The repository within the registry
       repository: nginxinc/nginx-unprivileged
+      # -- The image pull policy
       pullPolicy: IfNotPresent
       version: 1.23.2-alpine
       # chainguard image does not support the templates feature
@@ -77,6 +85,7 @@ insecureScheme:
       #   memory: 64Mi
 
 config:
+  # -- The loglevel
   logLevel: info
   domains:
     - localhost
@@ -93,11 +102,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
@@ -114,8 +123,9 @@ tolerations: []
 
 affinity: {}
 
+# -- Set the trust domain to be used for the SPIFFE identifiers
 trustDomain: example.org
-# -- This is the value of your clusters `kubeadm init --service-dns-domain` flag
+# -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
 clusterDomain: cluster.local
 
 telemetry:
@@ -130,8 +140,11 @@ telemetry:
 
     nginxExporter:
       image:
+        # -- The OCI registry to pull the image from
         registry: docker.io
+        # -- The repository within the registry
         repository: nginx/nginx-prometheus-exporter
+        # -- The image pull policy
         pullPolicy: IfNotPresent
         version: "0.11.0"
 

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -28,7 +28,7 @@ A Helm chart to install the SPIRE agent.
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
-| logLevel | string | `"info"` | The loglevel |
+| logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -51,7 +51,7 @@ A Helm chart to install the SPIRE agent.
 | telemetry.prometheus.port | int | `9988` |  |
 | trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
-| trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| trustDomain | string | `"example.org"` | The trust domain to be used for the SPIFFE identifiers |
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
 | waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -22,13 +22,13 @@ A Helm chart to install the SPIRE agent.
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | healthChecks.port | int | `9980` | override the host port used for health checking |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"spiffe/spire-agent"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| image.repository | string | `"spiffe/spire-agent"` | The repository within the registry |
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
-| logLevel | string | `"info"` |  |
+| logLevel | string | `"info"` | The loglevel |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -40,10 +40,10 @@ A Helm chart to install the SPIRE agent.
 | server.address | string | `""` |  |
 | server.namespaceOverride | string | `""` |  |
 | server.port | int | `8081` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| socketPath | string | `"/run/spire/agent-sockets/spire-agent.sock"` | The unix socket path to the spire-agent |
 | telemetry.prometheus.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
@@ -51,10 +51,10 @@ A Helm chart to install the SPIRE agent.
 | telemetry.prometheus.port | int | `9988` |  |
 | trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
-| trustDomain | string | `"example.org"` |  |
-| waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
-| waitForIt.image.registry | string | `"cgr.dev"` |  |
-| waitForIt.image.repository | string | `"chainguard/wait-for-it"` |  |
+| trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| waitForIt.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| waitForIt.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
+| waitForIt.image.repository | string | `"chainguard/wait-for-it"` | The repository within the registry |
 | waitForIt.image.version | string | `"latest-20230113"` |  |
 | waitForIt.resources | object | `{}` |  |
 | workloadAttestors.k8s.skipKubeletVerification | bool | `true` | If true, kubelet certificate verification is skipped |

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -57,11 +57,11 @@ resources: {}
 
 nodeSelector: {}
 
-# -- The loglevel
+# -- The log level, valid values are "debug", "info", "warn", and "error"
 logLevel: info
-# -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
+# -- The name of the Kubernetes cluster (`kubeadm init --service-dns-domain`)
 clusterName: example-cluster
-# -- Set the trust domain to be used for the SPIFFE identifiers
+# -- The trust domain to be used for the SPIFFE identifiers
 trustDomain: example.org
 # -- If set, obtain trust bundle from url instead of Kubernetes ConfigMap
 trustBundleURL: ""

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -3,8 +3,11 @@
 # Declare variables to be passed into your templates.
 
 image:
+  # -- The OCI registry to pull the image from
   registry: ghcr.io
+  # -- The repository within the registry
   repository: spiffe/spire-agent
+  # -- The image pull policy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   version: ""
@@ -15,11 +18,11 @@ namespaceOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
@@ -54,8 +57,11 @@ resources: {}
 
 nodeSelector: {}
 
+# -- The loglevel
 logLevel: info
+# -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
 clusterName: example-cluster
+# -- Set the trust domain to be used for the SPIFFE identifiers
 trustDomain: example.org
 # -- If set, obtain trust bundle from url instead of Kubernetes ConfigMap
 trustBundleURL: ""
@@ -74,8 +80,11 @@ healthChecks:
 
 waitForIt:
   image:
+    # -- The OCI registry to pull the image from
     registry: cgr.dev
+    # -- The repository within the registry
     repository: chainguard/wait-for-it
+    # -- The image pull policy
     pullPolicy: IfNotPresent
     version: latest-20230113
   resources: {}
@@ -100,6 +109,7 @@ telemetry:
       namespace: ""
       labels: {}
 
+# -- The unix socket path to the spire-agent
 socketPath: /run/spire/agent-sockets/spire-agent.sock
 
 # -- Priority class assigned to daemonset pods

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # registry: gcr.io
-  # repository: spiffe-io/spire-agent
   registry: ghcr.io
   repository: spiffe/spire-agent
   pullPolicy: IfNotPresent

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -79,7 +79,7 @@ A Helm chart to install the SPIRE server.
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |
-| logLevel | string | `"info"` | The loglevel |
+| logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeAttestor.k8sPsat.enabled | bool | `true` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -41,9 +41,9 @@ A Helm chart to install the SPIRE server.
 | controllerManager.ignoreNamespaces[0] | string | `"kube-system"` |  |
 | controllerManager.ignoreNamespaces[1] | string | `"kube-public"` |  |
 | controllerManager.ignoreNamespaces[2] | string | `"local-path-storage"` |  |
-| controllerManager.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controllerManager.image.registry | string | `"ghcr.io"` |  |
-| controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` |  |
+| controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | controllerManager.image.version | string | `"0.2.2"` |  |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
@@ -51,9 +51,9 @@ A Helm chart to install the SPIRE server.
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` |  |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"cgr.dev"` | The OCI registry to pull the image from |
+| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"chainguard/kubectl"` | The repository within the registry |
 | controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `"latest"` |  |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
@@ -72,14 +72,14 @@ A Helm chart to install the SPIRE server.
 | federation.bundleEndpoint.port | int | `8443` |  |
 | federation.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"spiffe/spire-server"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
+| image.repository | string | `"spiffe/spire-server"` | The repository within the registry |
 | image.version | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
-| jwtIssuer | string | `"oidc-discovery.example.org"` |  |
-| logLevel | string | `"info"` |  |
+| jwtIssuer | string | `"oidc-discovery.example.org"` | The JWT issuer domain |
+| logLevel | string | `"info"` | The loglevel |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeAttestor.k8sPsat.enabled | bool | `true` |  |
@@ -97,16 +97,16 @@ A Helm chart to install the SPIRE server.
 | service.annotations | object | `{}` |  |
 | service.port | int | `8081` |  |
 | service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | telemetry.prometheus.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.enabled | bool | `false` |  |
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-server |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |
-| trustDomain | string | `"example.org"` |  |
+| trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 | upstreamAuthority.certManager.enabled | bool | `false` |  |
 | upstreamAuthority.certManager.issuer_group | string | `"cert-manager.io"` |  |
 | upstreamAuthority.certManager.issuer_kind | string | `"Issuer"` |  |

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -103,7 +103,7 @@ dataStore:
     # -- Settings from https://github.com/spiffe/spire/blob/main/doc/plugin_server_datastore_sql.md go in this section
     plugin_data: {}
 
-# -- The loglevel
+# -- The log level, valid values are "debug", "info", "warn", and "error"
 logLevel: info
 # -- The JWT issuer domain
 jwtIssuer: oidc-discovery.example.org

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -6,8 +6,6 @@
 replicaCount: 1
 
 image:
-  # registry: gcr.io
-  # repository: spiffe-io/spire-server
   registry: ghcr.io
   repository: spiffe/spire-server
   pullPolicy: IfNotPresent

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -6,8 +6,11 @@
 replicaCount: 1
 
 image:
+  # -- The OCI registry to pull the image from
   registry: ghcr.io
+  # -- The repository within the registry
   repository: spiffe/spire-server
+  # -- The image pull policy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   version: ""
@@ -18,11 +21,11 @@ namespaceOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
@@ -100,10 +103,14 @@ dataStore:
     # -- Settings from https://github.com/spiffe/spire/blob/main/doc/plugin_server_datastore_sql.md go in this section
     plugin_data: {}
 
+# -- The loglevel
 logLevel: info
+# -- The JWT issuer domain
 jwtIssuer: oidc-discovery.example.org
 
+# -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
 clusterName: example-cluster
+# -- Set the trust domain to be used for the SPIFFE identifiers
 trustDomain: example.org
 
 bundleConfigMap: spire-bundle
@@ -155,8 +162,11 @@ controllerManager:
   enabled: false
 
   image:
+    # -- The OCI registry to pull the image from
     registry: ghcr.io
+    # -- The repository within the registry
     repository: spiffe/spire-controller-manager
+    # -- The image pull policy
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     version: "0.2.2"
@@ -212,8 +222,11 @@ controllerManager:
     failurePolicy: Fail
     upgradeHook:
       image:
+        # -- The OCI registry to pull the image from
         registry: cgr.dev
+        # -- The repository within the registry
         repository: chainguard/kubectl
+        # -- The image pull policy
         pullPolicy: IfNotPresent
         version: latest
 

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -4,9 +4,9 @@ global:
     # -- This is the value of your clusters `kubeadm init --service-dns-domain` flag
     clusterDomain: cluster.local
   spire:
-    # -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
+    # -- The name of the Kubernetes cluster (`kubeadm init --service-dns-domain`)
     clusterName: example-cluster
-    # -- Set the trust domain to be used for the SPIFFE identifiers
+    # -- The trust domain to be used for the SPIFFE identifiers
     trustDomain: example.org
     # -- Override all instances of bundleConfigMap
     bundleConfigMap: ""

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -4,9 +4,9 @@ global:
     # -- This is the value of your clusters `kubeadm init --service-dns-domain` flag
     clusterDomain: cluster.local
   spire:
-    # -- Set the name of the Kubernetes cluster
+    # -- Set the name of the Kubernetes cluster. (`kubeadm init --service-dns-domain`)
     clusterName: example-cluster
-    # -- Set the trust domain to use for the spiffe identifiers
+    # -- Set the trust domain to be used for the SPIFFE identifiers
     trustDomain: example.org
     # -- Override all instances of bundleConfigMap
     bundleConfigMap: ""

--- a/helm-docs.sh
+++ b/helm-docs.sh
@@ -42,5 +42,5 @@ else
 fi
 
 # validate docs
-"$SCRIPTPATH/bin/${exe}"
+"$SCRIPTPATH/bin/${exe}" --document-dependency-values
 git diff --exit-code


### PR DESCRIPTION
I have added a flag to the helm-docs script to include the documentation for dependencies.

This will add more complete documentation to https://artifacthub.io/packages/helm/spiffe/spire#values so it is easier for our users to get started and having a complete overview.