### PR TITLE
Add nodeSelector for tornjak

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -323,7 +323,7 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.namespaceOverride | string | `""` |  |
 | spire-server.nodeAttestor.k8sPsat.enabled | bool | `true` |  |
 | spire-server.nodeAttestor.k8sPsat.serviceAccountAllowList | list | `[]` |  |
-| spire-server.nodeSelector | object | `{}` |  |
+| spire-server.nodeSelector | object | `{}` | Select specific nodes to run on (currently only amd64 is supported by Tornjak) |
 | spire-server.notifier.k8sbundle.namespace | string | `""` | Namespace to push the bundle into, if blank will default to SPIRE Server namespace |
 | spire-server.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | spire-server.persistence.size | string | `"1Gi"` |  |
@@ -375,6 +375,7 @@ Kubernetes: `>=1.21.0-0`
 | tornjak-frontend.labels | object | `{}` |  |
 | tornjak-frontend.nameOverride | string | `""` |  |
 | tornjak-frontend.namespaceOverride | string | `""` |  |
+| tornjak-frontend.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Select specific nodes to run on (currently only amd64 is supported by Tornjak) |
 | tornjak-frontend.podSecurityContext | object | `{}` |  |
 | tornjak-frontend.securityContext | object | `{}` |  |
 | tornjak-frontend.service.annotations | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -84,7 +84,7 @@ A Helm chart to install the SPIRE server.
 | namespaceOverride | string | `""` |  |
 | nodeAttestor.k8sPsat.enabled | bool | `true` |  |
 | nodeAttestor.k8sPsat.serviceAccountAllowList | list | `[]` |  |
-| nodeSelector | object | `{}` |  |
+| nodeSelector | object | `{}` | Select specific nodes to run on (currently only amd64 is supported by Tornjak) |
 | notifier.k8sbundle.namespace | string | `""` | Namespace to push the bundle into, if blank will default to SPIRE Server namespace |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.size | string | `"1Gi"` |  |

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -70,6 +70,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- Select specific nodes to run on (currently only amd64 is supported by Tornjak)
 nodeSelector: {}
 
 tolerations: []

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -59,6 +59,7 @@ port forwarding. See the chart NOTES output for more details.
 | labels | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
+| nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Select specific nodes to run on (currently only amd64 is supported by Tornjak) |
 | podSecurityContext | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
+++ b/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /usr/src/app/node_modules/.cache
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: cache
           emptyDir: {}

--- a/charts/spire/charts/tornjak-frontend/values.yaml
+++ b/charts/spire/charts/tornjak-frontend/values.yaml
@@ -41,6 +41,10 @@ service:
   port: 3000
   annotations: {}
 
+# -- Select specific nodes to run on (currently only amd64 is supported by Tornjak)
+nodeSelector:
+  kubernetes.io/arch: amd64
+
 # -- Provide minimal resources to prevent accidental crashes due to resource exhaustion
 # resources:
 #   requests:
@@ -59,4 +63,3 @@ apiServerURL: "http://localhost:10000/"  # 👈 Use it for minikube or kind
 spireHealthCheck:
   # -- Enables the SPIRE Healthchecker indicator
   enabled: true
-


### PR DESCRIPTION
Tornjak only supports amd64 builds at the moment

To prevent deployment failures on clusters with arm64 nodes I have added a nodeSelector for tornjak frontend, and documentation for spire-server.

Didn't define the nodeSelector on spire-server because by default Tornjak isn't deployed and therefore doesn't require to run entire spire-server on amd64. So resolved it there using a documentation update.

Also see https://github.com/spiffe/tornjak/issues/219
