### PR TITLE
Remove manual dispatch from dummy workflow

### DIFF
--- a/.github/workflows/helm-chart-ci-ignore.yaml
+++ b/.github/workflows/helm-chart-ci-ignore.yaml
@@ -1,7 +1,6 @@
 name: Helm Chart CI
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [synchronize, opened, reopened]
     paths-ignore:


### PR DESCRIPTION
This jobs just runs on docs updates to satisfy the PR merge requirements, as it doesn't do anything, there is not really a need to manually run it as it is only a requirement for PRs.

Signed-off-by: Marco Franssen <marco.franssen@gmail.com>
