### PR TITLE
Allow to use spire-server as an upstream authority

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -390,6 +390,9 @@ Kubernetes: `>=1.21.0-0`
 | spire-server.upstreamAuthority.disk.secret.create | bool | `true` | If disabled requires you to create a secret with the given keys (certificate, key and optional bundle) yourself. |
 | spire-server.upstreamAuthority.disk.secret.data | object | `{"bundle":"","certificate":"","key":""}` | If secret creation is enabled, will create a secret with following certificate info |
 | spire-server.upstreamAuthority.disk.secret.name | string | `"spiffe-upstream-ca"` | If secret creation is disabled, the secret with this name will be used. |
+| spire-server.upstreamAuthority.spire.enabled | bool | `false` |  |
+| spire-server.upstreamAuthority.spire.server.address | string | `""` |  |
+| spire-server.upstreamAuthority.spire.server.port | int | `8081` |  |
 | tornjak-frontend.affinity | object | `{}` |  |
 | tornjak-frontend.apiServerURL | string | `"http://localhost:10000/"` | URL of the Tornjak APIs (backend) Since Tornjak Frontend runs in the browser, this URL must be accessible from the machine running a browser. |
 | tornjak-frontend.fullnameOverride | string | `""` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -144,5 +144,8 @@ A Helm chart to install the SPIRE server.
 | upstreamAuthority.disk.secret.create | bool | `true` | If disabled requires you to create a secret with the given keys (certificate, key and optional bundle) yourself. |
 | upstreamAuthority.disk.secret.data | object | `{"bundle":"","certificate":"","key":""}` | If secret creation is enabled, will create a secret with following certificate info |
 | upstreamAuthority.disk.secret.name | string | `"spiffe-upstream-ca"` | If secret creation is disabled, the secret with this name will be used. |
+| upstreamAuthority.spire.enabled | bool | `false` |  |
+| upstreamAuthority.spire.server.address | string | `""` |  |
+| upstreamAuthority.spire.server.port | int | `8081` |  |
 
 ----------------------------------------------

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- define "spire-server.yaml-config" -}}
+{{- $upstreamAuthorityUsed := 0 }}
 {{- $root := . }}
 server:
   bind_address: "0.0.0.0"
@@ -59,6 +60,7 @@ plugins:
 
   {{- with .Values.upstreamAuthority.disk }}
   {{- if eq (.enabled | toString) "true" }}
+  {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
   UpstreamAuthority:
     - disk:
         plugin_data:
@@ -72,6 +74,7 @@ plugins:
 
   {{- with .Values.upstreamAuthority.certManager }}
   {{- if eq (.enabled | toString) "true" }}
+  {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
   UpstreamAuthority:
     - cert-manager:
         plugin_data:
@@ -87,6 +90,7 @@ plugins:
 
   {{- with .Values.upstreamAuthority.spire }}
   {{- if eq (.enabled | toString) "true" }}
+  {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
   UpstreamAuthority:
     - spire:
         plugin_data:
@@ -95,6 +99,9 @@ plugins:
           workload_api_socket: "/run/spire/upstream_agent/spire-agent.sock"
   {{- end }}
   {{- end }}
+{{- if gt $upstreamAuthorityUsed 1 }}
+{{- fail "Too many Upstream Authorities used. You can only enable one." }}
+{{- end }}
 
 health_checks:
   listener_enabled: true

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -100,7 +100,7 @@ plugins:
   {{- end }}
   {{- end }}
 {{- if gt $upstreamAuthorityUsed 1 }}
-{{- fail "Too many Upstream Authorities used. You can only enable one." }}
+{{- fail "You can only enable a single Upstream Authority." }}
 {{- end }}
 
 health_checks:

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -85,6 +85,17 @@ plugins:
   {{- end }}
   {{- end }}
 
+  {{- with .Values.upstreamAuthority.spire }}
+  {{- if eq (.enabled | toString) "true" }}
+  UpstreamAuthority:
+    - spire:
+        plugin_data:
+          server_address: {{ .server.address | quote }}
+          server_port: {{ .server.port }}
+          workload_api_socket: "/run/spire/upstream_agent/spire-agent.sock"
+  {{- end }}
+  {{- end }}
+
 health_checks:
   listener_enabled: true
   bind_address: "0.0.0.0"

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -175,6 +175,11 @@ upstreamAuthority:
     # -- Specify to use a namespace other then the one the chart is installed into
     namespace: ""
     kube_config_file: ""
+  spire:
+    enabled: false
+    server:
+      address: ""
+      port: 8081
 
 notifier:
   k8sbundle:


### PR DESCRIPTION
These are the bare minimum configurables required for the nested spire use case:
https://spiffe.io/docs/latest/architecture/nested/readme/