### PR TITLE
Fix hooks for K3s

### DIFF
--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Create the name of the service account to use
 {{- $root := deepCopy . }}
 {{- $tag := (default $root.image.tag $root.image.version) | toString }}
 {{- if eq (len $tag) 0 }}
-{{- $_ := set $root.image "tag" $root.KubeVersion }}
+{{- $_ := set $root.image "tag" (regexReplaceAll "([^\\+]*)\\+?.*" $root.KubeVersion "${1}") }}
 {{- end }}
 {{- include "spire-lib.image" $root }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Create the name of the service account to use
 {{- $root := deepCopy . }}
 {{- $tag := (default $root.image.tag $root.image.version) | toString }}
 {{- if eq (len $tag) 0 }}
-{{- $_ := set $root.image "tag" (regexReplaceAll "([^\\+]*)\\+?.*" $root.KubeVersion "${1}") }}
+{{- $_ := set $root.image "tag" (regexReplaceAll "^(v?\\d+\\.\\d+\\.\\d+).*" $root.KubeVersion "${1}") }}
 {{- end }}
 {{- include "spire-lib.image" $root }}
 {{- end }}


### PR DESCRIPTION
Running on k3s the KubeVersion shows up as `v1.25.4+k3s1` for me. This gives the follwwing error in the post-install hook container:
```
  Warning  InspectFailed  8s (x5 over 37s)  kubelet            Failed to apply default image tag "docker.io/rancher/kubectl:v1.25.4+k3s1": couldn't parse image reference "docker.io/rancher/kubectl:v1.25.4+k3s1": invalid reference format
```

This PR strips out the `+` and everything after it. The regex is not optimal, its very broad. Would be great if a regex master could help tighten it down.
