### PR TITLE
Fix bundle role/rolebinding naming conflict

### DIFF
--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}-bundle
+  name: {{ $namespace }}-{{ include "spire-server.fullname" . }}-bundle
   namespace: {{ .Values.notifier.k8sbundle.namespace | default $namespace }}
 rules:
   - apiGroups: [""]
@@ -50,7 +50,7 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "spire-server.fullname" . }}-bundle
+  name: {{ $namespace }}-{{ include "spire-server.fullname" . }}-bundle
   namespace: {{ .Values.notifier.k8sbundle.namespace | default $namespace }}
 subjects:
   - kind: ServiceAccount
@@ -58,7 +58,7 @@ subjects:
     namespace: {{ $namespace }}
 roleRef:
   kind: Role
-  name: {{ include "spire-server.fullname" . }}-bundle
+  name: {{ $namespace }}-{{ include "spire-server.fullname" . }}-bundle
   apiGroup: rbac.authorization.k8s.io
 
 {{- if and .Values.nodeAttestor.k8sPsat.enabled }}


### PR DESCRIPTION
When you install a primary and a secondary deployment in the same Kubernetes cluster, use the same release name (spire), and configure the primary to give the bundle to the secondary, both releases want to own the same role/rolebinding name. This patch adds the release namespace into the names to prevent conflict.