### PR TITLE
Add missing global values to charts

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -1,3 +1,6 @@
+# @ignored
+global: {}
+
 # -- Set the csi driver name deployed to Kubernetes.
 pluginName: csi.spiffe.io
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# @ignored
+global: {}
+
 # -- The name of the spire-agent unix socket
 agentSocketName: spire-agent.sock
 

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# @ignored
+global: {}
+
 image:
   # -- The OCI registry to pull the image from
   registry: ghcr.io

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# @ignored
+global: {}
+
 # -- SPIRE server currently runs with a sqlite database. Scaling to multiple instances will not work until we use an external database.
 replicaCount: 1
 

--- a/charts/spire/charts/tornjak-frontend/values.yaml
+++ b/charts/spire/charts/tornjak-frontend/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# @ignored
+global: {}
+
 image:
   registry: ghcr.io
   repository: spiffe/tornjak-frontend


### PR DESCRIPTION
If you try and install the chart its missing the global key at the root of the chart that many macro's are expecting. This pr adds the missing key so that it works.