### PR TITLE
Allow for having no registry specified

### DIFF
--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -32,9 +32,11 @@
 
 {{- define "spire-lib.registry" }}
 {{- if ne (len (dig "spire" "image" "registry" "" .global)) 0 }}
-{{- .global.spire.image.registry }}
+{{- print .global.spire.image.registry "/"}}
+{{- else if ne (len (.image.registry)) 0 }}
+{{- print .image.registry "/"}}
 {{- else }}
-{{- .image.registry }}
+{{- print ""}}
 {{- end }}
 {{- end }}
 
@@ -45,11 +47,11 @@
 {{- if eq (substr 0 7 $tag) "sha256:" }}
 {{- printf "%s/%s@%s" $registry $repo $tag }}
 {{- else if .appVersion }}
-{{- printf "%s/%s:%s" $registry $repo (default .appVersion $tag) }}
+{{- printf "%s%s:%s" $registry $repo (default .appVersion $tag) }}
 {{- else if $tag }}
-{{- printf "%s/%s:%s" $registry $repo $tag }}
+{{- printf "%s%s:%s" $registry $repo $tag }}
 {{- else }}
-{{- printf "%s/%s" $registry $repo }}
+{{- printf "%s%s" $registry $repo }}
 {{- end }}
 {{- end }}
 

--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -35,8 +35,6 @@
 {{- print .global.spire.image.registry "/"}}
 {{- else if ne (len (.image.registry)) 0 }}
 {{- print .image.registry "/"}}
-{{- else }}
-{{- print ""}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Trying to use a local registry gives the following error:

```
  Warning  InspectFailed  54s (x6 over 63s)  kubelet            Failed to apply default image tag "/spire-server:latest-local": couldn't parse image reference "/spire-server:latest-local": invalid reference format
  Warning  Failed         54s (x6 over 63s)  kubelet            Error: InvalidImageName
```

Config I used:
```
  image:
    registry: ""
    repository: "spire-server"
    tag: "latest-local"
```

This PR allow the `image.registry` field to be empty for local registries.