### PR TITLE
Bump k8s versions to latest patches

### DIFF
--- a/.github/workflows/helm-chart-ci-ignore.yaml
+++ b/.github/workflows/helm-chart-ci-ignore.yaml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.27.0
-          - v1.26.3
-          - v1.25.8
+          - v1.27.2
+          - v1.26.4
+          - v1.25.9
         values:
           - ${{ fromJson(needs.build-matrix.outputs.tests) }}
 

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -61,7 +61,7 @@ jobs:
           if [ $res -eq 0 ]; then
             {
               echo "## Hardcoded images"
-              echo 
+              echo
               echo ":x: These templates were found to be using statically defined images and not overridable ones. Please fix."
               echo
               cat /tmp/findings
@@ -136,10 +136,10 @@ jobs:
         # Kubernetes, but can go back farther as long as we don't need heroics
         # to pull it off (i.e. kubectl version juggling).
         k8s:
-          - v1.27.0
-          - v1.26.3
-          - v1.25.8
-          - v1.24.12
+          - v1.27.2
+          - v1.26.4
+          - v1.25.9
+          - v1.24.13
           - v1.23.17
           - v1.22.17
         values:


### PR DESCRIPTION
@faisal-memon we will need to update the required checks in branch protection to use the new version
