### PR TITLE
Removed pull_request edited event from ci workflow

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -3,7 +3,7 @@ name: Helm Chart CI
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, edited]
+    types: [synchronize, opened, reopened]
     paths:
       - 'charts/**'
       - '.github/workflows/helm-chart-ci.yaml'
@@ -61,7 +61,7 @@ jobs:
           if [ $res -eq 0 ]; then
             {
               echo "## Hardcoded images"
-              echo 
+              echo
               echo ":x: These templates were found to be using statically defined images and not overridable ones. Please fix."
               echo
               cat /tmp/findings


### PR DESCRIPTION
Edited event is only useful if you want a workflow to act on a PR description or title or labels and such, we are not doing that in this workflow.

Removing the edited type from the event doesn't unnecessarily run the workflow again when title, description and such are changed.
