### PR TITLE
Emergency patch for Tornjak Frontend

### DIFF
--- a/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
+++ b/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              ln -s /tmp/env.js build/env.js
+              npx react-inject-env set -n /tmp/env.js
+              serve -s build -p $PORT_FE
           ports:
             - name: http
               containerPort: 3000
@@ -52,7 +59,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cache
-              mountPath: /usr/src/app/
+              mountPath: /usr/src/app/node_modules/.cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Tornjak Frontend serves incorrect dashboard due to restricted namespace. 
Fixing the cache file location leads to this error:
```Error: EACCES: permission denied, open './build/env.js'```

Solution, to redirect the env.js output to writeable space e.g. /tmp