### PR TITLE
Improve Tornjak backend test

### DIFF
--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -163,6 +163,7 @@ spec:
           startupProbe:
             httpGet:
               scheme: HTTP
+              path: /api/tornjak/serverinfo
               port: 10000
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           args:

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -15,7 +15,13 @@ spec:
     - name: curl-tornjak-backend
       image: cgr.dev/chainguard/bash:latest
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.port }}']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.port }}/api/tornjak/serverinfo']
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+    - name: curl-tornjak-backend-and-spire
+      image: cgr.dev/chainguard/bash:latest
+      command: ['curl']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.port }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never


### PR DESCRIPTION
Current test only checks if the web server is operational. This test validates the appropriate path can be executed and it validates if the backend can access SPIRE Server (healthcheck)