### PR TITLE
Upgrade Tornjak to image v1.2.2

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -388,7 +388,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | spire-server.tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |
 | spire-server.tornjak.image.repository | string | `"spiffe/tornjak-backend"` | The repository within the registry |
-| spire-server.tornjak.image.tag | string | `"v1.2.1"` | Overrides the image tag |
+| spire-server.tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | spire-server.tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.tornjak.resources | object | `{}` |  |
 | spire-server.tornjak.service.annotations | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -134,7 +134,7 @@ A Helm chart to install the SPIRE server.
 | tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |
 | tornjak.image.repository | string | `"spiffe/tornjak-backend"` | The repository within the registry |
-| tornjak.image.tag | string | `"v1.2.1"` | Overrides the image tag |
+| tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak.resources | object | `{}` |  |
 | tornjak.service.annotations | object | `{}` |  |

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -337,7 +337,7 @@ tornjak:
     # -- This value is deprecated in favor of tag. (Will be removed in a future release)
     version: ""
     # -- Overrides the image tag
-    tag: "v1.2.1"
+    tag: "v1.2.2"
   service:
     type: ClusterIP
     port: 10000

--- a/charts/spire/charts/tornjak-frontend/Chart.yaml
+++ b/charts/spire/charts/tornjak-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: tornjak-frontend
 description: A Helm chart to deploy Tornjak frontend
 type: application
 version: 0.1.0
-appVersion: "v1.2.1"
+appVersion: "v1.2.2"
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:
   - https://github.com/spiffe/tornjak

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.1](https://img.shields.io/badge/AppVersion-v1.2.1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.2](https://img.shields.io/badge/AppVersion-v1.2.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart to deploy Tornjak frontend

--- a/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
+++ b/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /usr/src/app/node_modules/.cache
+            - name: env
+              mountPath: /usr/src/app/build/tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,4 +74,6 @@ spec:
       {{- end }}
       volumes:
         - name: cache
+          emptyDir: {}
+        - name: env
           emptyDir: {}

--- a/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
+++ b/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
@@ -28,13 +28,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              ln -s /tmp/env.js build/env.js
-              npx react-inject-env set -n /tmp/env.js
-              serve -s build -p $PORT_FE
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
Upgrade Tornjak image to version v1.2.2 (https://github.com/spiffe/tornjak/releases/tag/v1.2.2)

- Resolving issue #326 (remove an emergency patch) 
- Refactor and improve Tornajk image build process