### PR TITLE
Add TLS/mTLS support for Tornjak

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -400,7 +400,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.topologySpreadConstraints | list | `[]` |  |
 | spire-server.tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| spire-server.tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
+| spire-server.tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | spire-server.tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | spire-server.tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
 | spire-server.tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -399,7 +399,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| spire-server.tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | spire-server.tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | spire-server.tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
 | spire-server.tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |
@@ -410,6 +409,10 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | spire-server.tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.tornjak.resources | object | `{}` |  |
+| spire-server.tornjak.service.annotations | object | `{}` |  |
+| spire-server.tornjak.service.portHttp | int | `10080` |  |
+| spire-server.tornjak.service.portHttps | int | `10443` |  |
+| spire-server.tornjak.service.type | string | `"ClusterIP"` |  |
 | spire-server.tornjak.startupProbe.failureThreshold | int | `3` |  |
 | spire-server.tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |
 | spire-server.tornjak.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -398,7 +398,16 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
-| spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
+| spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
+| spire-server.tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
+| spire-server.tornjak.config.http.port | int | `10000` | Container port value for HTTP |
+| spire-server.tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
+| spire-server.tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
+| spire-server.tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
+| spire-server.tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.tls.port | int | `20000` | Container port value for TLS |
+| spire-server.tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | spire-server.tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | spire-server.tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |
@@ -406,9 +415,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | spire-server.tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.tornjak.resources | object | `{}` |  |
-| spire-server.tornjak.service.annotations | object | `{}` |  |
-| spire-server.tornjak.service.port | int | `10000` |  |
-| spire-server.tornjak.service.type | string | `"ClusterIP"` |  |
 | spire-server.tornjak.startupProbe.failureThreshold | int | `3` |  |
 | spire-server.tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |
 | spire-server.tornjak.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -402,10 +402,15 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | spire-server.tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | spire-server.tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| spire-server.tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.mtls.ca | string | `"/opt/spire/sample-keys/rootCA.pem"` | CA for mTLS connection |
+| spire-server.tornjak.config.mtls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for mTLS connection |
+| spire-server.tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.mtls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for mTLS connection |
 | spire-server.tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | spire-server.tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| spire-server.tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.tls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for TLS connection |
+| spire-server.tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.tls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for TLS connection |
 | spire-server.tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | spire-server.tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -402,11 +402,11 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | spire-server.tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | spire-server.tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| spire-server.tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' and 'userSecret' must be created prior to installing this chart |
 | spire-server.tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | spire-server.tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
 | spire-server.tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
-| spire-server.tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| spire-server.tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' must be created prior to installing this chart |
 | spire-server.tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | spire-server.tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | spire-server.tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -400,9 +400,10 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.topologySpreadConstraints | list | `[]` |  |
 | spire-server.tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| spire-server.tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | spire-server.tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
-| spire-server.tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification (required for `mtls` connectionType) |
+| spire-server.tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
+| spire-server.tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
+| spire-server.tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | spire-server.tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | spire-server.tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -398,7 +398,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
-| spire-server.tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
 | spire-server.tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | spire-server.tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -402,17 +402,14 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | spire-server.tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | spire-server.tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| spire-server.tornjak.config.mtls.ca | string | `"/opt/spire/sample-keys/rootCA.pem"` | CA for mTLS connection |
-| spire-server.tornjak.config.mtls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for mTLS connection |
-| spire-server.tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service |
-| spire-server.tornjak.config.mtls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for mTLS connection |
+| spire-server.tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
 | spire-server.tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | spire-server.tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| spire-server.tornjak.config.tls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for TLS connection |
-| spire-server.tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service |
-| spire-server.tornjak.config.tls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for TLS connection |
+| spire-server.tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
+| spire-server.tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
 | spire-server.tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | spire-server.tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
+| spire-server.tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | spire-server.tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | spire-server.tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -398,18 +398,11 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
+| spire-server.tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| spire-server.tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
-| spire-server.tornjak.config.http.port | int | `10000` | Container port value for HTTP |
-| spire-server.tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| spire-server.tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' and 'userSecret' must be created prior to installing this chart |
-| spire-server.tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
-| spire-server.tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| spire-server.tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
-| spire-server.tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' must be created prior to installing this chart |
-| spire-server.tornjak.config.tls.port | int | `20000` | Container port value for TLS |
-| spire-server.tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
-| spire-server.tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |
+| spire-server.tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
+| spire-server.tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
+| spire-server.tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification (required for `mtls` connectionType) |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | spire-server.tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | spire-server.tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -149,10 +149,15 @@ A Helm chart to install the SPIRE server.
 | tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.mtls.ca | string | `"/opt/spire/sample-keys/rootCA.pem"` | CA for mTLS connection |
+| tornjak.config.mtls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for mTLS connection |
+| tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service |
+| tornjak.config.mtls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for mTLS connection |
 | tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.tls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for TLS connection |
+| tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service |
+| tornjak.config.tls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for TLS connection |
 | tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -35,11 +35,11 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 * Backend (this chart) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
 * [Frontend](../tornjak-frontend/README.md) - Tornjak UI
 
-When Tornjak is enabled, it is exposed on both http and https (if TLS server certs are configured). Tornjak handles a permanent redirect from `http` to `https` to ensure users always use the https endpoint.
+When Tornjak is enabled, it can be reached in one of the three connection types:
 
-In addition to that you can configure a `client certificate authority`, this will make Tornjak backend verify Client certificates signed by this authority to enable mTLS authentication.
-
-> **Warning**: For production ensure to configure the certificates including CA, to protect Tornjak from unauthorized access.
+* HTTP - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
+* TLS - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
+* mTLS - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
 
 Tornjak automatically determines the connection type based on provided information. See below.
 

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -145,18 +145,11 @@ A Helm chart to install the SPIRE server.
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |
+| tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
-| tornjak.config.http.port | int | `10000` | Container port value for HTTP |
-| tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' and 'userSecret' must be created prior to installing this chart |
-| tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
-| tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
-| tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' must be created prior to installing this chart |
-| tornjak.config.tls.port | int | `20000` | Container port value for TLS |
-| tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
-| tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |
+| tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
+| tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
+| tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification (required for `mtls` connectionType) |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -37,13 +37,13 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 
 When Tornjak is enabled, it can be reached in one of the three connection types:
 
-* http - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
-* tls - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
-* mtls - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+* HTTP - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
+* TLS - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
+* mTLS - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
 
-### Tornjak with TLS
+Tornjak automatically determines the connection type based on provided information. See below.
 
-`tornjak.config.connectionType=tls`
+### Tornjak with TLS Connection Type
 
 TLS connection requires Tornjak to have access to TLS key and certificate.
 Complete instruction on creating your own TLS certificate can be found [here](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md).
@@ -59,9 +59,7 @@ Once the charts are deployed, you can test the TLS connection with the following
 curl --cacert CA/rootCA.crt https://localhost:10443
 ```
 
-### Tornjak with mTLS
-
-`tornjak.config.connectionType=mtls`
+### Tornjak with mTLS Connection Type
 
 mTLS connection allows Tornjak server validation by client and Tornjak client validation by Tornjak server. The server validation is identical to above TLS. Follow the steps to create
 TLS secret with key and the certificate.
@@ -80,6 +78,10 @@ Once the charts are deployed, you can test the mTLS connection with the followin
 ```console
 curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10443
 ```
+
+### Tornjak with HTTP Connection Type
+
+In order to run Tornjak with simple HTTP Connection only, make sure you don't create any `Secrets` or `ConfigMaps` listed above.
 
 ## Values
 
@@ -198,7 +200,6 @@ curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhos
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |
-| tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
 | tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -37,13 +37,9 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 
 When Tornjak is enabled, it is exposed on both http and https (if TLS server certs are configured). Tornjak handles a permanent redirect from `http` to `https` to ensure users always use the https endpoint.
 
-In addition to that you can configure a `client certificate authority`, this will make Tornjak backend verify Client certificates signed by this authority to enable mTLS authentication.
+In addition, you can configure a `client certificate authority`, this will make Tornjak backend verify Client certificates signed by this authority to enable mTLS authentication.
 
-> **Warning**: For production ensure to configure the certificates including CA, to protect Tornjak from unauthorized access.
-
-Tornjak automatically determines the connection type based on provided information. See below.
-
-**Warning**: For production, we recommend configuring tls certificates and client CA to protect Tornjak from unauthorized access.
+**Warning**: For production, we recommend configuring TLS certificates and client CA to protect Tornjak from unauthorized access.
 
 ### Tornjak with TLS Connection Type
 

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -147,9 +147,10 @@ A Helm chart to install the SPIRE server.
 | topologySpreadConstraints | list | `[]` |  |
 | tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
-| tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification (required for `mtls` connectionType) |
+| tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
+| tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
+| tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -30,7 +30,10 @@ A Helm chart to install the SPIRE server.
 
 ## Tornjak
 
-Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak)
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak) and it is composed of two components:
+
+* Backend (this chart) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
+* [Frontend](../tornjak-frontend/README.md) - Tornjak UI
 
 When Tornjak is enabled, it can be reached in one of the three connection types:
 
@@ -53,7 +56,7 @@ kubectl -n spire-server create secret tls tornjak-tls-secret --cert=client.crt -
 Once the charts are deployed, you can test the TLS connection with the following command (assuming localhost):
 
 ```console
-curl --cacert CA/rootCA.crt https://localhost:10000
+curl --cacert CA/rootCA.crt https://localhost:10443
 ```
 
 ### Tornjak with mTLS
@@ -75,7 +78,7 @@ kubectl -n spire-server create secret generic tornjak-user-ca --from-file=ca.crt
 Once the charts are deployed, you can test the mTLS connection with the following command (assuming localhost):
 
 ```console
-curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10000
+curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10443
 ```
 
 ## Values

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -43,6 +43,8 @@ When Tornjak is enabled, it can be reached in one of the three connection types:
 
 Tornjak automatically determines the connection type based on provided information. See below.
 
+**Warning**: For production, we recommend configuring tls certificates and client CA to protect Tornjak from unauthorized access.
+
 ### Tornjak with TLS Connection Type
 
 TLS connection requires Tornjak to have access to TLS key and certificate.

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -197,7 +197,7 @@ curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhos
 | topologySpreadConstraints | list | `[]` |  |
 | tornjak.config.connectionType | string | `"http"` | Tornjak supports 3 connection types: `http`, `tls`, and `mtls`. Select only one. |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| tornjak.config.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
+| tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
 | tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -149,11 +149,11 @@ A Helm chart to install the SPIRE server.
 | tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' and 'userSecret' must be created prior to installing this chart |
 | tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
 | tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
-| tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service. When 'true', the 'serverSecret' must be created prior to installing this chart |
 | tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -201,7 +201,6 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
-| tornjak.config.service | object | `{"annotations":{},"portHttp":10080,"portHttps":10443,"type":"ClusterIP"}` | Enables the service for a given `connectionType` |
 | tornjak.config.tlsSecret | string | `"tornjak-tls-secret"` | Name of the secret containing server side key and certificate for TLS verification (required for `tls` or `mtls` connectionType) |
 | tornjak.config.userCA.name | string | `"tornjak-user-ca"` |  |
 | tornjak.config.userCA.type | string | `"Secret"` | Type of delivery for the user CA for mTLS client verification options are `Secret` or `ConfigMap` (required for `mtls` connectionType) |
@@ -212,6 +211,10 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak.resources | object | `{}` |  |
+| tornjak.service.annotations | object | `{}` |  |
+| tornjak.service.portHttp | int | `10080` |  |
+| tornjak.service.portHttps | int | `10443` |  |
+| tornjak.service.type | string | `"ClusterIP"` |  |
 | tornjak.startupProbe.failureThreshold | int | `3` |  |
 | tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |
 | tornjak.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -145,7 +145,16 @@ A Helm chart to install the SPIRE server.
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |
-| tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
+| tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | Persistent DB for storing Tornjak specific information |
+| tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
+| tornjak.config.http.port | int | `10000` | Container port value for HTTP |
+| tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
+| tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
+| tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
+| tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
+| tornjak.config.tls.port | int | `20000` | Container port value for TLS |
+| tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |
@@ -153,9 +162,6 @@ A Helm chart to install the SPIRE server.
 | tornjak.image.tag | string | `"v1.2.2"` | Overrides the image tag |
 | tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak.resources | object | `{}` |  |
-| tornjak.service.annotations | object | `{}` |  |
-| tornjak.service.port | int | `10000` |  |
-| tornjak.service.type | string | `"ClusterIP"` |  |
 | tornjak.startupProbe.failureThreshold | int | `3` |  |
 | tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |
 | tornjak.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -149,17 +149,14 @@ A Helm chart to install the SPIRE server.
 | tornjak.config.http.enabled | bool | `true` | Enables Tornjak HTTP (insecure) service |
 | tornjak.config.http.port | int | `10000` | Container port value for HTTP |
 | tornjak.config.http.service | object | `{"annotations":{},"port":10000,"type":"ClusterIP"}` | Service to handle Tornjak HTTP connection |
-| tornjak.config.mtls.ca | string | `"/opt/spire/sample-keys/rootCA.pem"` | CA for mTLS connection |
-| tornjak.config.mtls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for mTLS connection |
-| tornjak.config.mtls.enabled | bool | `false` | Enables Tornjak TLS service |
-| tornjak.config.mtls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for mTLS connection |
+| tornjak.config.mtls.enabled | bool | `true` | Enables Tornjak TLS service |
 | tornjak.config.mtls.port | int | `30000` | Container port value for mTLS |
 | tornjak.config.mtls.service | object | `{"annotations":{},"port":30000,"type":"ClusterIP"}` | Service to handle Tornjak mTLS connection |
-| tornjak.config.tls.cert | string | `"/opt/spire/sample-keys/cert.pem"` | Certificate for TLS connection |
-| tornjak.config.tls.enabled | bool | `false` | Enables Tornjak TLS service |
-| tornjak.config.tls.key | string | `"/opt/spire/sample-keys/key.pem"` | Key for TLS connection |
+| tornjak.config.serverSecret | string | `"tornjak-server-secret"` | Name of the secret containing server side key and certificate for TLS verification |
+| tornjak.config.tls.enabled | bool | `true` | Enables Tornjak TLS service |
 | tornjak.config.tls.port | int | `20000` | Container port value for TLS |
 | tornjak.config.tls.service | object | `{"annotations":{},"port":20000,"type":"ClusterIP"}` | Service to handle Tornjak TLS connection |
+| tornjak.config.userSecret | string | `"tornjak-user-secret"` | Name of the secret containing user CA for mTLS verification |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
 | tornjak.image.pullPolicy | string | `"IfNotPresent"` | The Tornjak image pull policy |
 | tornjak.image.registry | string | `"ghcr.io"` | The OCI registry to pull the Tornjak image from |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -35,11 +35,11 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 * Backend (this chart) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
 * [Frontend](../tornjak-frontend/README.md) - Tornjak UI
 
-When Tornjak is enabled, it can be reached in one of the three connection types:
+When Tornjak is enabled, it is exposed on both http and https (if TLS server certs are configured). Tornjak handles a permanent redirect from `http` to `https` to ensure users always use the https endpoint.
 
-* HTTP - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
-* TLS - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
-* mTLS - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+In addition to that you can configure a `client certificate authority`, this will make Tornjak backend verify Client certificates signed by this authority to enable mTLS authentication.
+
+> **Warning**: For production ensure to configure the certificates including CA, to protect Tornjak from unauthorized access.
 
 Tornjak automatically determines the connection type based on provided information. See below.
 

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -28,6 +28,56 @@ A Helm chart to install the SPIRE server.
 
 * <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
 
+## Tornjak
+
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak)
+
+When Tornjak is enabled, it can be reached in one of the three connection types:
+
+* http - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
+* tls - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
+* mtls - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+
+### Tornjak with TLS
+
+`tornjak.config.connectionType=tls`
+
+TLS connection requires Tornjak to have access to TLS key and certificate.
+Complete instruction on creating your own TLS certificate can be found [here](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md).
+TLS Certificate and the private key must be provided to Tornjak via *TLS Secret*. Prior to deploying this Helm chart, create TLS Secret in the deployment namespace (e.g. `spire-server`)
+
+```console
+kubectl -n spire-server create secret tls tornjak-tls-secret --cert=client.crt --key=client.key
+```
+
+Once the charts are deployed, you can test the TLS connection with the following command (assuming localhost):
+
+```console
+curl --cacert CA/rootCA.crt https://localhost:10000
+```
+
+### Tornjak with mTLS
+
+`tornjak.config.connectionType=mtls`
+
+mTLS connection allows Tornjak server validation by client and Tornjak client validation by Tornjak server. The server validation is identical to above TLS. Follow the steps to create
+TLS secret with key and the certificate.
+
+Additionally, you must provide the user CA to Tornjak server via `Secret` or `ConfigMap`.
+Follow the steps to [create user CA for mTLS](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md), then create a *Secret* (or *ConfigMap*) prior to deploying this Helm chart.
+
+Here is an example using a *Secret* in `spire-server` namespace:
+
+```console
+kubectl -n spire-server create secret generic tornjak-user-ca --from-file=ca.crt="CA/rootCA.crt"
+```
+
+Once the charts are deployed, you can test the mTLS connection with the following command (assuming localhost):
+
+```console
+curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10000
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -30,15 +30,11 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 * Backend (this chart) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
 * [Frontend](../tornjak-frontend/README.md) - Tornjak UI
 
-When Tornjak is enabled, it can be reached in one of the three connection types:
+When Tornjak is enabled, it is exposed on both http and https (if TLS server certs are configured). Tornjak handles a permanent redirect from `http` to `https` to ensure users always use the https endpoint.
 
-* HTTP - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
-* TLS - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
-* mTLS - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+In addition, you can configure a `client certificate authority`, this will make Tornjak backend verify Client certificates signed by this authority to enable mTLS authentication.
 
-Tornjak automatically determines the connection type based on provided information. See below.
-
-**Warning**: For production, we recommend configuring tls certificates and client CA to protect Tornjak from unauthorized access.
+**Warning**: For production, we recommend configuring TLS certificates and client CA to protect Tornjak from unauthorized access.
 
 ### Tornjak with TLS Connection Type
 

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -25,7 +25,10 @@
 
 ## Tornjak
 
-Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak)
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak) and it is composed of two components:
+
+* Backend (this chart) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
+* [Frontend](../tornjak-frontend/README.md) - Tornjak UI
 
 When Tornjak is enabled, it can be reached in one of the three connection types:
 
@@ -48,7 +51,7 @@ kubectl -n spire-server create secret tls tornjak-tls-secret --cert=client.crt -
 Once the charts are deployed, you can test the TLS connection with the following command (assuming localhost):
 
 ```console
-curl --cacert CA/rootCA.crt https://localhost:10000
+curl --cacert CA/rootCA.crt https://localhost:10443
 ```
 
 ### Tornjak with mTLS
@@ -70,7 +73,7 @@ kubectl -n spire-server create secret generic tornjak-user-ca --from-file=ca.crt
 Once the charts are deployed, you can test the mTLS connection with the following command (assuming localhost):
 
 ```console
-curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10000
+curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10443
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -23,6 +23,56 @@
 
 {{ template "chart.requirementsSection" . }}
 
+## Tornjak
+
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak)
+
+When Tornjak is enabled, it can be reached in one of the three connection types:
+
+* http - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
+* tls - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
+* mtls - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+
+### Tornjak with TLS
+
+`tornjak.config.connectionType=tls`
+
+TLS connection requires Tornjak to have access to TLS key and certificate.
+Complete instruction on creating your own TLS certificate can be found [here](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md).
+TLS Certificate and the private key must be provided to Tornjak via *TLS Secret*. Prior to deploying this Helm chart, create TLS Secret in the deployment namespace (e.g. `spire-server`)
+
+```console
+kubectl -n spire-server create secret tls tornjak-tls-secret --cert=client.crt --key=client.key
+```
+
+Once the charts are deployed, you can test the TLS connection with the following command (assuming localhost):
+
+```console
+curl --cacert CA/rootCA.crt https://localhost:10000
+```
+
+### Tornjak with mTLS
+
+`tornjak.config.connectionType=mtls`
+
+mTLS connection allows Tornjak server validation by client and Tornjak client validation by Tornjak server. The server validation is identical to above TLS. Follow the steps to create
+TLS secret with key and the certificate.
+
+Additionally, you must provide the user CA to Tornjak server via `Secret` or `ConfigMap`.
+Follow the steps to [create user CA for mTLS](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md), then create a *Secret* (or *ConfigMap*) prior to deploying this Helm chart.
+
+Here is an example using a *Secret* in `spire-server` namespace:
+
+```console
+kubectl -n spire-server create secret generic tornjak-user-ca --from-file=ca.crt="CA/rootCA.crt"
+```
+
+Once the charts are deployed, you can test the mTLS connection with the following command (assuming localhost):
+
+```console
+curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10000
+```
+
 {{ template "chart.valuesSection" . }}
 
 ----------------------------------------------

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -32,13 +32,13 @@ Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak
 
 When Tornjak is enabled, it can be reached in one of the three connection types:
 
-* http - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
-* tls - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
-* mtls - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
+* HTTP - simple HTTP connection recommended for demonstration purpose only. It should not be use for production.
+* TLS - enables Transport Layer Security (TLS) with HTTPS communication. Tornjak client can validate Tornjak server using TLS Certificate (see instructions below)
+* mTLS - mutual TLS. Both, Tornjak client and the server can validate each other using provided certificates (see instructions below)
 
-### Tornjak with TLS
+Tornjak automatically determines the connection type based on provided information. See below.
 
-`tornjak.config.connectionType=tls`
+### Tornjak with TLS Connection Type
 
 TLS connection requires Tornjak to have access to TLS key and certificate.
 Complete instruction on creating your own TLS certificate can be found [here](https://github.com/spiffe/tornjak/blob/main/examples/tls_mtls/README.md).
@@ -54,9 +54,7 @@ Once the charts are deployed, you can test the TLS connection with the following
 curl --cacert CA/rootCA.crt https://localhost:10443
 ```
 
-### Tornjak with mTLS
-
-`tornjak.config.connectionType=mtls`
+### Tornjak with mTLS Connection Type
 
 mTLS connection allows Tornjak server validation by client and Tornjak client validation by Tornjak server. The server validation is identical to above TLS. Follow the steps to create
 TLS secret with key and the certificate.
@@ -75,6 +73,10 @@ Once the charts are deployed, you can test the mTLS connection with the followin
 ```console
 curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:10443
 ```
+
+### Tornjak with HTTP Connection Type
+
+In order to run Tornjak with simple HTTP Connection only, make sure you don't create any `Secrets` or `ConfigMaps` listed above.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/spire/charts/spire-server/README.md.gotmpl
+++ b/charts/spire/charts/spire-server/README.md.gotmpl
@@ -38,6 +38,8 @@ When Tornjak is enabled, it can be reached in one of the three connection types:
 
 Tornjak automatically determines the connection type based on provided information. See below.
 
+**Warning**: For production, we recommend configuring tls certificates and client CA to protect Tornjak from unauthorized access.
+
 ### Tornjak with TLS Connection Type
 
 TLS connection requires Tornjak to have access to TLS key and certificate.

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -15,9 +15,20 @@ Tornjak runs without authentication and is therefore NOT suitable to run in prod
 Only use in test environments!
 
 Access Tornjak:
-
-    kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }} {{ .Values.tornjak.service.port }}:10000
-
-Open browser to: http://localhost:{{ .Values.tornjak.service.port }}
-
+{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+HTTP:
+  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-http {{ .Values.tornjak.config.http.service.port }}:{{ .Values.tornjak.config.http.port }}
+  Open browser to: http://localhost:{{ .Values.tornjak.config.http.service.port }}
+{{- end }}
+{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+TLS:
+  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-tls {{ .Values.tornjak.config.tls.service.port }}:{{ .Values.tornjak.config.tls.port }}
+  Open browser to: https://localhost:{{ .Values.tornjak.config.tls.service.port }}
+  *** NOTE: You might get a security warning if using self-signed certificate
+{{- end }}
+{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+mTLS:
+  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-mtls {{ .Values.tornjak.config.mtls.service.port }}:{{ .Values.tornjak.config.mtls.port }}
+  curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.mtls.service.port }}
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -16,16 +16,16 @@ Only use in test environments!
 
 Access Tornjak:
    kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.config.service.port }}:10000
-{{- if eq .Values.tornjak.config.connectionType "http" }}
+{{- if eq (include "spire-tornjak.connectionType" .) "http" }}
 HTTP:
   Open browser to: http://localhost:{{ .Values.tornjak.config.service.port }}
-{{- else if eq .Values.tornjak.config.connectionType "tls" }}
+{{- else if eq (include "spire-tornjak.connectionType" .) "tls" }}
 TLS:
   Open browser to: https://localhost:{{ .Values.tornjak.config.service.port }}
   *** NOTE: You might get a security warning if using self-signed certificate
   or use curl:
   curl  --cacert CA/rootCA.crt https://localhost:{{ .Values.tornjak.config.service.port }}
-{{- else if eq .Values.tornjak.config.connectionType "mtls" }}
+{{- else if eq (include "spire-tornjak.connectionType" .) "mtls" }}
 mTLS:
   curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.service.port }}
 {{- else }}

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -15,20 +15,20 @@ Tornjak runs without authentication and is therefore NOT suitable to run in prod
 Only use in test environments!
 
 Access Tornjak:
-{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+   kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.config.service.port }}:10000
+{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
 HTTP:
-  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-http {{ .Values.tornjak.config.http.service.port }}:{{ .Values.tornjak.config.http.port }}
-  Open browser to: http://localhost:{{ .Values.tornjak.config.http.service.port }}
-{{- end }}
-{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+  Open browser to: http://localhost:{{ .Values.tornjak.config.service.port }}
+{{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
 TLS:
-  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-tls {{ .Values.tornjak.config.tls.service.port }}:{{ .Values.tornjak.config.tls.port }}
-  Open browser to: https://localhost:{{ .Values.tornjak.config.tls.service.port }}
+  Open browser to: https://localhost:{{ .Values.tornjak.config.service.port }}
   *** NOTE: You might get a security warning if using self-signed certificate
-{{- end }}
-{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+  or use curl:
+  curl  --cacert CA/rootCA.crt https://localhost:{{ .Values.tornjak.config.service.port }}
+{{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
 mTLS:
-  kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.backend" . }}-mtls {{ .Values.tornjak.config.mtls.service.port }}:{{ .Values.tornjak.config.mtls.port }}
-  curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.mtls.service.port }}
+  curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.service.port }}
+{{- else }}
+  ERROR! Incorrect value selected for "Values.tornjak.config.connectionType"
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -15,19 +15,22 @@ Tornjak runs without authentication and is therefore NOT suitable to run in prod
 Only use in test environments!
 
 Access Tornjak:
-   kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.config.service.port }}:10000
+   kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.service.portHttp }}:10080
 {{- if eq (include "spire-tornjak.connectionType" .) "http" }}
-HTTP:
-  Open browser to: http://localhost:{{ .Values.tornjak.config.service.port }}
+  Open browser to: http://localhost:{{ .Values.tornjak.service.portHttp }}
 {{- else if eq (include "spire-tornjak.connectionType" .) "tls" }}
-TLS:
-  Open browser to: https://localhost:{{ .Values.tornjak.config.service.port }}
+  Open browser to: https://localhost:{{ .Values.tornjak.service.portHttps }}
+
   *** NOTE: You might get a security warning if using self-signed certificate
   or use curl:
-  curl  --cacert CA/rootCA.crt https://localhost:{{ .Values.tornjak.config.service.port }}
-{{- else if eq (include "spire-tornjak.connectionType" .) "mtls" }}
-mTLS:
-  curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.service.port }}
+
+    curl --cacert certs/ca.crt https://localhost:{{ .Values.tornjak.service.portHttps }}
+  {{- if eq (include "spire-tornjak.connectionType" .) "mtls" }}
+
+  Or provide a client certificate and key to use mTLS authentication:
+
+    curl --cacert certs/ca.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.service.portHttps }}
+  {{- end }}
 {{- else }}
   ERROR! Incorrect value selected for "Values.tornjak.config.connectionType"
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -16,16 +16,16 @@ Only use in test environments!
 
 Access Tornjak:
    kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.config.service.port }}:10000
-{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
+{{- if eq .Values.tornjak.config.connectionType "http" }}
 HTTP:
   Open browser to: http://localhost:{{ .Values.tornjak.config.service.port }}
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
+{{- else if eq .Values.tornjak.config.connectionType "tls" }}
 TLS:
   Open browser to: https://localhost:{{ .Values.tornjak.config.service.port }}
   *** NOTE: You might get a security warning if using self-signed certificate
   or use curl:
   curl  --cacert CA/rootCA.crt https://localhost:{{ .Values.tornjak.config.service.port }}
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
+{{- else if eq .Values.tornjak.config.connectionType "mtls" }}
 mTLS:
   curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:{{ .Values.tornjak.config.service.port }}
 {{- else }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -179,14 +179,14 @@ The code below does the verification of all the requirements.
 {{- if eq .Values.tornjak.config.connectionType "http" -}}
 {{- include "spire-tornjak.backend" . -}}
 
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
+{{- else if eq .Values.tornjak.config.connectionType "tls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.tlsSecret) -}}
 {{- $secret := default "NAME NOT SET" .Values.tornjak.config.tlsSecret }}
 {{- fail (printf "ERROR: When 'connectionType==tls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $secret "spire-server") }}
 {{- end }}
 {{- include "spire-tornjak.backend" . -}}
 
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
+{{- else if eq .Values.tornjak.config.connectionType "mtls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.tlsSecret) -}}
 {{- $secret := default "NAME NOT SET" .Values.tornjak.config.tlsSecret }}
 {{- fail (printf "ERROR: When 'connectionType==mtls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $secret "spire-server") }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -178,15 +178,18 @@ mTLS Connection Types requires UserSecret to be set before the deployment
 {{- include "spire-tornjak.backend" . -}}-http
 {{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.serverSecret) -}}
-{{- fail "ERROR: When 'connectionType==tls', secret '.Values.tornjak.config.serverSecret' must be created in 'spire-server' namespace prior to the helm deployment" }}
+{{- $secret := default "NAME NOT SET" .Values.tornjak.config.serverSecret }}
+{{- fail (printf "ERROR: When 'connectionType==tls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $secret "spire-server") }}
 {{- end }}
 {{- include "spire-tornjak.backend" . -}}-tls
 {{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.serverSecret) -}}
-{{- fail "ERROR: When 'connectionType==mtls', secret '.Values.tornjak.config.serverSecret' must be created in 'spire-server' namespace prior to the helm deployment" }}
+{{- $secret := default "NAME NOT SET" .Values.tornjak.config.serverSecret }}
+{{- fail (printf "ERROR: When 'connectionType==mtls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $secret "spire-server") }}
 {{- end }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.userSecret) -}}
-{{- fail "ERROR: When 'connectionType==mtls', secret '.Values.tornjak.config.userSecret' must be created in 'spire-server' namespace prior to the helm deployment" }}
+{{- $uSecret := default "NAME NOT SET" .Values.tornjak.config.userSecret }}
+{{- fail (printf "ERROR: When 'connectionType==mtls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $uSecret "spire-server") }}
 {{- end }}
 {{- include "spire-tornjak.backend" . -}}-mtls
 {{- else }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -171,19 +171,20 @@ Tornjak specific section
 
 {{/*
 TLS and mTLS Connection Types require tlsSecret to be set before the deployment
-mTLS Connection Types requires userCA.name to be set before the deployment
+mTLS Connection Types requires userCA.name to be set before the deployment.
+The code below does the verification of all the requirements.
 */}}
 {{- define "spire-tornjak.servicename" -}}
 
 {{- if eq .Values.tornjak.config.connectionType "http" -}}
-{{- include "spire-tornjak.backend" . -}}-http
+{{- include "spire-tornjak.backend" . -}}
 
 {{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.tlsSecret) -}}
 {{- $secret := default "NAME NOT SET" .Values.tornjak.config.tlsSecret }}
 {{- fail (printf "ERROR: When 'connectionType==tls', secret '%s' must be created in '%s' namespace prior to the helm deployment" $secret "spire-server") }}
 {{- end }}
-{{- include "spire-tornjak.backend" . -}}-tls
+{{- include "spire-tornjak.backend" . -}}
 
 {{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
 {{- if not (lookup "v1" "Secret" "spire-server" .Values.tornjak.config.tlsSecret) -}}
@@ -195,19 +196,26 @@ mTLS Connection Types requires userCA.name to be set before the deployment
 {{- $caName := default "NAME NOT SET" .Values.tornjak.config.userCA.name }}
 {{- fail (printf "ERROR: When 'connectionType==mtls', %s '%s' must be created in '%s' namespace prior to the helm deployment" $caType $caName "spire-server") }}
 {{- end }}
-{{- include "spire-tornjak.backend" . -}}-mtls
+{{- include "spire-tornjak.backend" . -}}
 
 {{- else }}
 {{- fail "ERROR: invalid option selected for '.Values.tornjak.config.connectionType' " -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "spire-tornjak.portname" -}}
-{{- if eq .Values.tornjak.config.connectionType "http" -}}
-tornjak-http
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" -}}
-tornjak-tls
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "mtls" -}}
-tornjak-mtls
+
+{{- define "spire-tornjak.service-portname-http" -}}
+tornjak-srv-http
 {{- end -}}
+
+{{- define "spire-tornjak.service-portname-https" -}}
+tornjak-srv-https
+{{- end -}}
+
+{{- define "spire-tornjak.target-portname-http" -}}
+tornjak-http
+{{- end -}}
+
+{{- define "spire-tornjak.target-portname-https" -}}
+tornjak-https
 {{- end -}}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -202,20 +202,3 @@ The code below does the verification of all the requirements.
 {{- fail "ERROR: invalid option selected for '.Values.tornjak.config.connectionType' " -}}
 {{- end -}}
 {{- end -}}
-
-
-{{- define "spire-tornjak.service-portname-http" -}}
-tornjak-srv-http
-{{- end -}}
-
-{{- define "spire-tornjak.service-portname-https" -}}
-tornjak-srv-https
-{{- end -}}
-
-{{- define "spire-tornjak.target-portname-http" -}}
-tornjak-http
-{{- end -}}
-
-{{- define "spire-tornjak.target-portname-https" -}}
-tornjak-https
-{{- end -}}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -203,25 +203,3 @@ tornjak-tls
 tornjak-mtls
 {{- end -}}
 {{- end -}}
-
-{{/*
-TLS Connection Type requires Server Secret to be set before the deployment
-
-{{- define "spire-tornjak.servicename" -}}
-{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
-{{ include "spire-tornjak.backend" . }}-http
-
-{{- else if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
- {{- if not (lookup "v1" "Secret" .Release.Namespace .Values.tornjak.config.serverSecret) -}}
- {{- fail "secret .Values.tornjak.config.serverSecret must be created prior to the helm deployment" }}
- {{- end }}
-{{ include "spire-tornjak.backend" . }}-tls
-{{- end }}
-{{- end }}
-
-{{- define "spire-tornjak.portname" -}}
-{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
-tornjak-http
-{{- end }}
-{{- end }}
-*/}}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -189,10 +189,10 @@ spec:
             - --tornjak-config
             - /run/spire/tornjak-config/server.conf
           ports:
-            - name: http
+            - name: tornjak-http
               containerPort: 10080
               protocol: TCP
-            - name: https
+            - name: tornjak-https
               containerPort: 10443
               protocol: TCP
           resources:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -209,11 +209,11 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-            {{- if or (eq .Values.tornjak.config.connectionType "tls") (eq .Values.tornjak.config.connectionType "mtls") }}
+            {{- if or (eq (include "spire-tornjak.connectionType" .) "tls") (eq (include "spire-tornjak.connectionType" .) "mtls") }}
             - name: server-cert
               mountPath: /opt/spire/server
             {{- end }}
-            {{- if eq .Values.tornjak.config.connectionType "mtls" }}
+            {{- if eq (include "spire-tornjak.connectionType" .) "mtls" }}
             - name: user-cert
               mountPath: /opt/spire/user
             {{- end }}
@@ -246,13 +246,13 @@ spec:
           emptyDir: {}
         - name: spire-controller-manager-tmp
           emptyDir: {}
-        {{- if or (eq .Values.tornjak.config.connectionType "tls") (eq .Values.tornjak.config.connectionType "mtls") }}
+        {{- if or (eq (include "spire-tornjak.connectionType" .) "tls") (eq (include "spire-tornjak.connectionType" .) "mtls") }}
         - name: server-cert
           secret:
             defaultMode: 256
             secretName: {{ .Values.tornjak.config.tlsSecret }}
         {{- end }}
-        {{- if eq .Values.tornjak.config.connectionType "mtls" }}
+        {{- if eq (include "spire-tornjak.connectionType" .) "mtls" }}
         {{- if eq .Values.tornjak.config.userCA.type "Secret" }}
         - name: user-cert
           secret:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -175,21 +175,35 @@ spec:
             {{- toYaml .Values.controllerManager.securityContext | nindent 12 }}
           image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tornjak.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.tornjak.image.pullPolicy }}
+          {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
           startupProbe:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: 10000
+              port: {{ .Values.tornjak.config.http.port }}
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
+          {{- end }}
           args:
             - --spire-config
             - /run/spire/config/server.conf
             - --tornjak-config
             - /run/spire/tornjak-config/server.conf
           ports:
-            - name: tornjak
-              containerPort: 10000
+            {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+            - name: tornjak-http
+              containerPort: {{ .Values.tornjak.config.http.port }}
               protocol: TCP
+            {{- end }}
+            {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+            - name: tornjak-tls
+              containerPort: {{ .Values.tornjak.config.tls.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+            - name: tornjak-mtls
+              containerPort: {{ .Values.tornjak.config.mtls.port }}
+              protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.tornjak.resources | nindent 12 }}
           volumeMounts:
@@ -204,6 +218,10 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
+            {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
+            - name: certs
+              mountPath: /opt/spire/sample-keys
+            {{- end }}
         {{- end }}
 
         {{- if gt (len .Values.extraContainers) 0 }}
@@ -233,6 +251,12 @@ spec:
           emptyDir: {}
         - name: spire-controller-manager-tmp
           emptyDir: {}
+        {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
+        - name: certs
+          secret:
+            defaultMode: 256
+            secretName: tornjak-certs
+        {{- end }}
         {{- if eq (.Values.upstreamAuthority.disk.enabled | toString) "true" }}
         - name: upstream-ca
           secret:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: {{ .Values.tornjak.config.http.port }}
+              port: 10000
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           {{- end }}
           args:
@@ -192,17 +192,6 @@ spec:
             - name: {{ include "spire-tornjak.portname" . }}
               containerPort: 10000
               protocol: TCP
-            {{- end }}
-            {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
-            - name: tornjak-tls
-              containerPort: {{ .Values.tornjak.config.tls.port }}
-              protocol: TCP
-            {{- end }}
-            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
-            - name: tornjak-mtls
-              containerPort: {{ .Values.tornjak.config.mtls.port }}
-              protocol: TCP
-            {{- end }}
           resources:
             {{- toYaml .Values.tornjak.resources | nindent 12 }}
           volumeMounts:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: 10000
+              port: 10080
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           {{- end }}
           args:
@@ -189,8 +189,11 @@ spec:
             - --tornjak-config
             - /run/spire/tornjak-config/server.conf
           ports:
-            - name: {{ include "spire-tornjak.portname" . }}
-              containerPort: 10000
+            - name: {{ include "spire-tornjak.target-portname-http" . }}
+              containerPort: 10080
+              protocol: TCP
+            - name: {{ include "spire-tornjak.target-portname-https" . }}
+              containerPort: 10443
               protocol: TCP
           resources:
             {{- toYaml .Values.tornjak.resources | nindent 12 }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -247,13 +247,19 @@ spec:
         - name: server-cert
           secret:
             defaultMode: 256
-            secretName: {{ .Values.tornjak.config.serverSecret }}
+            secretName: {{ .Values.tornjak.config.tlsSecret }}
         {{- end }}
         {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
+        {{- if eq (.Values.tornjak.config.userCA.type | toString) "Secret" }}
         - name: user-cert
           secret:
             defaultMode: 256
-            secretName: {{ .Values.tornjak.config.userSecret }}
+            secretName: {{ .Values.tornjak.config.userCA.name }}
+        {{- else if eq (.Values.tornjak.config.userCA.type | toString) "ConfigMap" }}
+        - name: user-cert
+          configMap:
+            name: {{ .Values.tornjak.config.userCA.name }}
+        {{- end }}
         {{- end }}
         {{- if eq (.Values.upstreamAuthority.disk.enabled | toString) "true" }}
         - name: upstream-ca

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -175,7 +175,7 @@ spec:
             {{- toYaml .Values.controllerManager.securityContext | nindent 12 }}
           image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tornjak.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.tornjak.image.pullPolicy }}
-          {{- if eq .Values.tornjak.config.connectionType "http" }}
+          {{- if eq (include "spire-tornjak.connectionType" .) "http" }}
           startupProbe:
             httpGet:
               scheme: HTTP

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -189,10 +189,10 @@ spec:
             - --tornjak-config
             - /run/spire/tornjak-config/server.conf
           ports:
-            - name: {{ include "spire-tornjak.target-portname-http" . }}
+            - name: http
               containerPort: 10080
               protocol: TCP
-            - name: {{ include "spire-tornjak.target-portname-https" . }}
+            - name: https
               containerPort: 10443
               protocol: TCP
           resources:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -175,12 +175,12 @@ spec:
             {{- toYaml .Values.controllerManager.securityContext | nindent 12 }}
           image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tornjak.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.tornjak.image.pullPolicy }}
-          {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+          {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
           startupProbe:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: {{ .Values.tornjak.config.http.port }}
+              port: 10000
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           {{- end }}
           args:
@@ -189,21 +189,9 @@ spec:
             - --tornjak-config
             - /run/spire/tornjak-config/server.conf
           ports:
-            {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
-            - name: tornjak-http
-              containerPort: {{ .Values.tornjak.config.http.port }}
+            - name: {{ include "spire-tornjak.portname" . }}
+              containerPort: 10000
               protocol: TCP
-            {{- end }}
-            {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
-            - name: tornjak-tls
-              containerPort: {{ .Values.tornjak.config.tls.port }}
-              protocol: TCP
-            {{- end }}
-            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
-            - name: tornjak-mtls
-              containerPort: {{ .Values.tornjak.config.mtls.port }}
-              protocol: TCP
-            {{- end }}
           resources:
             {{- toYaml .Values.tornjak.resources | nindent 12 }}
           volumeMounts:
@@ -218,11 +206,11 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-            {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
+            {{- if or (eq (.Values.tornjak.config.connectionType | toString) "tls") (eq (.Values.tornjak.config.connectionType | toString) "mtls") }}
             - name: server-cert
               mountPath: /opt/spire/server
             {{- end }}
-            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+            {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
             - name: user-cert
               mountPath: /opt/spire/user
             {{- end }}
@@ -255,13 +243,13 @@ spec:
           emptyDir: {}
         - name: spire-controller-manager-tmp
           emptyDir: {}
-        {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
+        {{- if or (eq (.Values.tornjak.config.connectionType | toString) "tls") (eq (.Values.tornjak.config.connectionType | toString) "mtls") }}
         - name: server-cert
           secret:
             defaultMode: 256
             secretName: {{ .Values.tornjak.config.serverSecret }}
         {{- end }}
-        {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+        {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
         - name: user-cert
           secret:
             defaultMode: 256

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: 10000
+              port: {{ .Values.tornjak.config.http.port }}
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           {{- end }}
           args:
@@ -192,6 +192,17 @@ spec:
             - name: {{ include "spire-tornjak.portname" . }}
               containerPort: 10000
               protocol: TCP
+            {{- end }}
+            {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+            - name: tornjak-tls
+              containerPort: {{ .Values.tornjak.config.tls.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+            - name: tornjak-mtls
+              containerPort: {{ .Values.tornjak.config.mtls.port }}
+              protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.tornjak.resources | nindent 12 }}
           volumeMounts:

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -175,7 +175,7 @@ spec:
             {{- toYaml .Values.controllerManager.securityContext | nindent 12 }}
           image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tornjak.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.tornjak.image.pullPolicy }}
-          {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
+          {{- if eq .Values.tornjak.config.connectionType "http" }}
           startupProbe:
             httpGet:
               scheme: HTTP
@@ -209,11 +209,11 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-            {{- if or (eq (.Values.tornjak.config.connectionType | toString) "tls") (eq (.Values.tornjak.config.connectionType | toString) "mtls") }}
+            {{- if or (eq .Values.tornjak.config.connectionType "tls") (eq .Values.tornjak.config.connectionType "mtls") }}
             - name: server-cert
               mountPath: /opt/spire/server
             {{- end }}
-            {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
+            {{- if eq .Values.tornjak.config.connectionType "mtls" }}
             - name: user-cert
               mountPath: /opt/spire/user
             {{- end }}
@@ -246,19 +246,19 @@ spec:
           emptyDir: {}
         - name: spire-controller-manager-tmp
           emptyDir: {}
-        {{- if or (eq (.Values.tornjak.config.connectionType | toString) "tls") (eq (.Values.tornjak.config.connectionType | toString) "mtls") }}
+        {{- if or (eq .Values.tornjak.config.connectionType "tls") (eq .Values.tornjak.config.connectionType "mtls") }}
         - name: server-cert
           secret:
             defaultMode: 256
             secretName: {{ .Values.tornjak.config.tlsSecret }}
         {{- end }}
-        {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
-        {{- if eq (.Values.tornjak.config.userCA.type | toString) "Secret" }}
+        {{- if eq .Values.tornjak.config.connectionType "mtls" }}
+        {{- if eq .Values.tornjak.config.userCA.type "Secret" }}
         - name: user-cert
           secret:
             defaultMode: 256
             secretName: {{ .Values.tornjak.config.userCA.name }}
-        {{- else if eq (.Values.tornjak.config.userCA.type | toString) "ConfigMap" }}
+        {{- else if eq .Values.tornjak.config.userCA.type "ConfigMap" }}
         - name: user-cert
           configMap:
             name: {{ .Values.tornjak.config.userCA.name }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -219,8 +219,12 @@ spec:
               mountPath: /run/spire/data
               readOnly: false
             {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
-            - name: certs
-              mountPath: /opt/spire/sample-keys
+            - name: server-cert
+              mountPath: /opt/spire/server
+            {{- end }}
+            {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+            - name: user-cert
+              mountPath: /opt/spire/user
             {{- end }}
         {{- end }}
 
@@ -252,10 +256,16 @@ spec:
         - name: spire-controller-manager-tmp
           emptyDir: {}
         {{- if or (eq (.Values.tornjak.config.tls.enabled | toString) "true") (eq (.Values.tornjak.config.mtls.enabled | toString) "true") }}
-        - name: certs
+        - name: server-cert
           secret:
             defaultMode: 256
-            secretName: tornjak-certs
+            secretName: {{ .Values.tornjak.config.serverSecret }}
+        {{- end }}
+        {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+        - name: user-cert
+          secret:
+            defaultMode: 256
+            secretName: {{ .Values.tornjak.config.userSecret }}
         {{- end }}
         {{- if eq (.Values.upstreamAuthority.disk.enabled | toString) "true" }}
         - name: upstream-ca

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -1,5 +1,5 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
-{{- if eq .Values.tornjak.config.connectionType "http" }}
+{{- if eq (include "spire-tornjak.connectionType" .) "http" }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -12,7 +12,7 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-   {{- if eq (.Values.tornjak.config.connectionType | toString) "true" }}
+   {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -16,13 +16,13 @@ spec:
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.port }}/api/tornjak/serverinfo']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.portHttp }}/api/tornjak/serverinfo']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     - name: curl-tornjak-backend-and-spire
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.port }}/api/healthcheck']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.portHttp }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -12,17 +12,19 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
+   {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.port }}/api/tornjak/serverinfo']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}-http.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.http.service.port }}/api/tornjak/serverinfo']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     - name: curl-tornjak-backend-and-spire
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.port }}/api/healthcheck']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}-http.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.http.service.port }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -1,4 +1,5 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
+{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -12,7 +13,6 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-   {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
@@ -25,6 +25,6 @@ spec:
       args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.port }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-    {{- end }}
   restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -12,17 +12,17 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-   {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+   {{- if eq (.Values.tornjak.config.connectionType | toString) "true" }}
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}-http.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.http.service.port }}/api/tornjak/serverinfo']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.port }}/api/tornjak/serverinfo']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     - name: curl-tornjak-backend-and-spire
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.backend" . }}-http.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.http.service.port }}/api/healthcheck']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.port }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     {{- end }}

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -1,5 +1,5 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
-{{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
+{{- if eq .Values.tornjak.config.connectionType "http" }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
+++ b/charts/spire/charts/spire-server/templates/tests/test-tornjak-connection.yaml
@@ -16,13 +16,13 @@ spec:
     - name: curl-tornjak-backend
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.portHttp }}/api/tornjak/serverinfo']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.portHttp }}/api/tornjak/serverinfo']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
     - name: curl-tornjak-backend-and-spire
       image: {{ template "spire-lib.image" (dict "image" .Values.tests.bash.image "global" .Values.global) }}
       command: ['curl']
-      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.config.service.portHttp }}/api/healthcheck']
+      args: ['-k', '-s', '-f', 'http://{{ include "spire-tornjak.servicename" . }}.{{ include "spire-server.namespace" . }}.svc.{{ include "spire-lib.cluster-domain" . }}:{{ .Values.tornjak.service.portHttp }}/api/healthcheck']
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
   restartPolicy: Never

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -11,13 +11,13 @@ data:
       {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "10000" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "10080" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
       {{- end }}
       {{- if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
       tls {
         enabled = true
-        port = "10000" # container port for TLS connection
+        port = "10443" # container port for TLS connection
         cert = "/opt/spire/server/tls.crt" # TLS server cert
         key  = "/opt/spire/server/tls.key"  # TLS server key
       }
@@ -25,7 +25,7 @@ data:
       {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
       mtls {
         enabled = true
-        port = "10000" # container port for mTLS connection
+        port = "10443" # container port for mTLS connection
         cert = "/opt/spire/server/tls.crt" # mTLS server cert
         key  = "/opt/spire/server/tls.key"  # mTLS server key
         ca   = "/opt/spire/user/ca.crt"  # mTLS user CA

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -8,24 +8,24 @@ data:
   server.conf: |
     server {
       spire_socket_path = "unix:///tmp/spire-server/private/api.sock" # socket to communicate with SPIRE server
-      {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
+      {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "{{ .Values.tornjak.config.http.port }}" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "10000" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
       {{- end }}
-      {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+      {{- if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
       tls {
         enabled = true
-        port = "{{ .Values.tornjak.config.tls.port }}" # container port for TLS connection
+        port = "10000" # container port for TLS connection
         cert = "/opt/spire/server/tls.crt" # TLS server cert
         key  = "/opt/spire/server/tls.key"  # TLS server key
       }
       {{- end }}
-      {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+      {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
       mtls {
         enabled = true
-        port = "{{ .Values.tornjak.config.mtls.port }}" # container port for mTLS connection
+        port = "10000" # container port for mTLS connection
         cert = "/opt/spire/server/tls.crt" # mTLS server cert
         key  = "/opt/spire/server/tls.key"  # mTLS server key
         ca   = "/opt/spire/user/ca.crt"  # mTLS user CA

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -8,13 +8,13 @@ data:
   server.conf: |
     server {
       spire_socket_path = "unix:///tmp/spire-server/private/api.sock" # socket to communicate with SPIRE server
-      {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
+      {{- if eq .Values.tornjak.config.connectionType "http" }}
       http {
         enabled = true # if true, opens HTTP server
         port = "10080" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
       {{- end }}
-      {{- if eq (.Values.tornjak.config.connectionType | toString) "tls" }}
+      {{- if eq .Values.tornjak.config.connectionType "tls" }}
       tls {
         enabled = true
         port = "10443" # container port for TLS connection
@@ -22,7 +22,7 @@ data:
         key  = "/opt/spire/server/tls.key"  # TLS server key
       }
       {{- end }}
-      {{- if eq (.Values.tornjak.config.connectionType | toString) "mtls" }}
+      {{- if eq .Values.tornjak.config.connectionType "mtls" }}
       mtls {
         enabled = true
         port = "10443" # container port for mTLS connection

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -11,7 +11,7 @@ data:
       {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "10000" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "{{ .Values.tornjak.config.http.port }}" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
       {{- end }}
       {{- if eq (.Values.tornjak.config.connectionType | toString) "tls" }}

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -8,13 +8,13 @@ data:
   server.conf: |
     server {
       spire_socket_path = "unix:///tmp/spire-server/private/api.sock" # socket to communicate with SPIRE server
-      {{- if eq .Values.tornjak.config.connectionType "http" }}
+      {{- if eq (include "spire-tornjak.connectionType" .) "http" }}
       http {
         enabled = true # if true, opens HTTP server
         port = "10080" # if HTTP enabled, opens HTTP listen port at specified container port
       }
       {{- end }}
-      {{- if eq .Values.tornjak.config.connectionType "tls" }}
+      {{- if eq (include "spire-tornjak.connectionType" .) "tls" }}
       tls {
         enabled = true
         port = "10443" # container port for TLS connection
@@ -22,7 +22,7 @@ data:
         key  = "/opt/spire/server/tls.key"  # TLS server key
       }
       {{- end }}
-      {{- if eq .Values.tornjak.config.connectionType "mtls" }}
+      {{- if eq (include "spire-tornjak.connectionType" .) "mtls" }}
       mtls {
         enabled = true
         port = "10443" # container port for mTLS connection

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -8,11 +8,29 @@ data:
   server.conf: |
     server {
       spire_socket_path = "unix:///tmp/spire-server/private/api.sock" # socket to communicate with SPIRE server
-
+      {{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "10000" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "{{ .Values.tornjak.config.http.port }}" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
+      {{- end }}
+      {{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+      tls {
+        enabled = true
+        port = "{{ .Values.tornjak.config.tls.port }}" # container port for TLS connection
+        cert = "{{ .Values.tornjak.config.tls.cert }}" # TLS cert
+        key = "{{ .Values.tornjak.config.tls.key }}"  # TLS key
+      }
+      {{- end }}
+      {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+      mtls {
+        enabled = true
+        port = "{{ .Values.tornjak.config.mtls.port }}" # container port for mTLS connection
+        cert = "{{ .Values.tornjak.config.mtls.cert }}" # mTLS cert
+        key = "{{ .Values.tornjak.config.mtls.key }}"  # mTLS key
+        ca = "{{ .Values.tornjak.config.mtls.ca }}"  # mTLS CA
+      }
+      {{- end }}
     }
 
     plugins {

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -11,7 +11,7 @@ data:
       {{- if eq .Values.tornjak.config.connectionType "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "10080" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "10080" # if HTTP enabled, opens HTTP listen port at specified container port
       }
       {{- end }}
       {{- if eq .Values.tornjak.config.connectionType "tls" }}

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -11,7 +11,7 @@ data:
       {{- if eq (.Values.tornjak.config.connectionType | toString) "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "{{ .Values.tornjak.config.http.port }}" # if HTTP enabled, opens HTTP listen port at container port 10000
+        port = "10000" # if HTTP enabled, opens HTTP listen port at container port 10000
       }
       {{- end }}
       {{- if eq (.Values.tornjak.config.connectionType | toString) "tls" }}

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -18,17 +18,17 @@ data:
       tls {
         enabled = true
         port = "{{ .Values.tornjak.config.tls.port }}" # container port for TLS connection
-        cert = "{{ .Values.tornjak.config.tls.cert }}" # TLS cert
-        key = "{{ .Values.tornjak.config.tls.key }}"  # TLS key
+        cert = "/opt/spire/server/tls.crt" # TLS server cert
+        key  = "/opt/spire/server/tls.key"  # TLS server key
       }
       {{- end }}
       {{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
       mtls {
         enabled = true
         port = "{{ .Values.tornjak.config.mtls.port }}" # container port for mTLS connection
-        cert = "{{ .Values.tornjak.config.mtls.cert }}" # mTLS cert
-        key = "{{ .Values.tornjak.config.mtls.key }}"  # mTLS key
-        ca = "{{ .Values.tornjak.config.mtls.ca }}"  # mTLS CA
+        cert = "/opt/spire/server/tls.crt" # mTLS server cert
+        key  = "/opt/spire/server/tls.key"  # mTLS server key
+        ca   = "/opt/spire/user/ca.crt"  # mTLS user CA
       }
       {{- end }}
     }

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -15,12 +15,12 @@ spec:
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
-    - name: http
+    - name: tornjak-srv-http
       port: {{ .Values.tornjak.config.service.portHttp }}
-      targetPort: {{ include "spire-tornjak.target-portname-http" . }}
+      targetPort: tornjak-http
       protocol: TCP
-    - name: https
+    - name: tornjak-srv-https
       port: {{ .Values.tornjak.config.service.portHttps }}
-      targetPort: {{ include "spire-tornjak.target-portname-https" . }}
+      targetPort: tornjak-https
       protocol: TCP
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -1,70 +1,22 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
-{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}-http
-  {{- with .Values.tornjak.config.http.service.annotations }}
+  name: {{ include "spire-tornjak.servicename" . }}
+  {{- with .Values.tornjak.config.service.annotations }}
   annotations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.tornjak.config.http.service.type }}
+  type: {{ .Values.tornjak.config.service.type }}
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
-    - name: {{ include "spire-tornjak.backend" . }}-http
-      port: {{ .Values.tornjak.config.http.service.port }}
-      targetPort: tornjak-http
+    - name: {{ include "spire-tornjak.portname" . }}
+      port: {{ .Values.tornjak.config.service.port }}
+      targetPort: {{ include "spire-tornjak.portname" . }}
       protocol: TCP
-{{- end }}
-{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}-tls
-  {{- with .Values.tornjak.config.tls.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  labels:
-    {{- include "spire-server.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.tornjak.config.tls.service.type }}
-  selector:
-   {{- include "spire-server.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: {{ include "spire-tornjak.backend" . }}-tls
-      port: {{ .Values.tornjak.config.tls.service.port }}
-      targetPort: tornjak-tls
-      protocol: TCP
-{{- end }}
-{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}-mtls
-  {{- with .Values.tornjak.config.mtls.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  labels:
-    {{- include "spire-server.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.tornjak.config.mtls.service.type }}
-  selector:
-   {{- include "spire-server.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: {{ include "spire-tornjak.backend" . }}-mtls
-      port: {{ .Values.tornjak.config.mtls.service.port }}
-      targetPort: tornjak-mtls
-      protocol: TCP
-{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -4,23 +4,23 @@ kind: Service
 metadata:
   namespace: {{ include "spire-server.namespace" . }}
   name: {{ include "spire-tornjak.servicename" . }}
-  {{- with .Values.tornjak.config.service.annotations }}
+  {{- with .Values.tornjak.service.annotations }}
   annotations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.tornjak.config.service.type }}
+  type: {{ .Values.tornjak.service.type }}
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
     - name: tornjak-srv-http
-      port: {{ .Values.tornjak.config.service.portHttp }}
+      port: {{ .Values.tornjak.service.portHttp }}
       targetPort: tornjak-http
       protocol: TCP
     - name: tornjak-srv-https
-      port: {{ .Values.tornjak.config.service.portHttps }}
+      port: {{ .Values.tornjak.service.portHttps }}
       targetPort: tornjak-https
       protocol: TCP
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -15,11 +15,11 @@ spec:
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
-    - name: {{ include "spire-tornjak.service-portname-http" . }}
+    - name: http
       port: {{ .Values.tornjak.config.service.portHttp }}
       targetPort: {{ include "spire-tornjak.target-portname-http" . }}
       protocol: TCP
-    - name: {{ include "spire-tornjak.service-portname-https" . }}
+    - name: https
       port: {{ .Values.tornjak.config.service.portHttps }}
       targetPort: {{ include "spire-tornjak.target-portname-https" . }}
       protocol: TCP

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -1,5 +1,4 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
-{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,51 +19,4 @@ spec:
       port: {{ .Values.tornjak.config.service.port }}
       targetPort: {{ include "spire-tornjak.portname" . }}
       protocol: TCP
-{{- end }}
-{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}-tls
-  {{- with .Values.tornjak.config.tls.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  labels:
-    {{- include "spire-server.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.tornjak.config.tls.service.type }}
-  selector:
-   {{- include "spire-server.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: {{ include "spire-tornjak.backend" . }}-tls
-      port: {{ .Values.tornjak.config.tls.service.port }}
-      targetPort: tornjak-tls
-      protocol: TCP
-{{- end }}
-{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}-mtls
-  {{- with .Values.tornjak.config.mtls.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  labels:
-    {{- include "spire-server.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.tornjak.config.mtls.service.type }}
-  selector:
-   {{- include "spire-server.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: {{ include "spire-tornjak.backend" . }}-mtls
-      port: {{ .Values.tornjak.config.mtls.service.port }}
-      targetPort: tornjak-mtls
-      protocol: TCP
-{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -15,8 +15,12 @@ spec:
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
-    - name: {{ include "spire-tornjak.portname" . }}
-      port: {{ .Values.tornjak.config.service.port }}
-      targetPort: {{ include "spire-tornjak.portname" . }}
+    - name: {{ include "spire-tornjak.service-portname-http" . }}
+      port: {{ .Values.tornjak.config.service.portHttp }}
+      targetPort: {{ include "spire-tornjak.target-portname-http" . }}
+      protocol: TCP
+    - name: {{ include "spire-tornjak.service-portname-https" . }}
+      port: {{ .Values.tornjak.config.service.portHttps }}
+      targetPort: {{ include "spire-tornjak.target-portname-https" . }}
       protocol: TCP
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -1,4 +1,5 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
+{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +20,51 @@ spec:
       port: {{ .Values.tornjak.config.service.port }}
       targetPort: {{ include "spire-tornjak.portname" . }}
       protocol: TCP
+{{- end }}
+{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ include "spire-server.namespace" . }}
+  name: {{ include "spire-tornjak.backend" . }}-tls
+  {{- with .Values.tornjak.config.tls.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.tornjak.config.tls.service.type }}
+  selector:
+   {{- include "spire-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ include "spire-tornjak.backend" . }}-tls
+      port: {{ .Values.tornjak.config.tls.service.port }}
+      targetPort: tornjak-tls
+      protocol: TCP
+{{- end }}
+{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ include "spire-server.namespace" . }}
+  name: {{ include "spire-tornjak.backend" . }}-mtls
+  {{- with .Values.tornjak.config.mtls.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.tornjak.config.mtls.service.type }}
+  selector:
+   {{- include "spire-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ include "spire-tornjak.backend" . }}-mtls
+      port: {{ .Values.tornjak.config.mtls.service.port }}
+      targetPort: tornjak-mtls
+      protocol: TCP
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/tornjak-service.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-service.yaml
@@ -1,22 +1,70 @@
 {{- if eq (.Values.tornjak.enabled | toString) "true" }}
+{{- if eq (.Values.tornjak.config.http.enabled | toString) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ include "spire-server.namespace" . }}
-  name: {{ include "spire-tornjak.backend" . }}
-  {{- with .Values.tornjak.service.annotations }}
+  name: {{ include "spire-tornjak.backend" . }}-http
+  {{- with .Values.tornjak.config.http.service.annotations }}
   annotations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.tornjak.service.type }}
+  type: {{ .Values.tornjak.config.http.service.type }}
   selector:
    {{- include "spire-server.selectorLabels" . | nindent 4 }}
   ports:
-    - name: {{ include "spire-tornjak.backend" . }}
-      port: {{ .Values.tornjak.service.port }}
-      targetPort: tornjak
+    - name: {{ include "spire-tornjak.backend" . }}-http
+      port: {{ .Values.tornjak.config.http.service.port }}
+      targetPort: tornjak-http
       protocol: TCP
+{{- end }}
+{{- if eq (.Values.tornjak.config.tls.enabled | toString) "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ include "spire-server.namespace" . }}
+  name: {{ include "spire-tornjak.backend" . }}-tls
+  {{- with .Values.tornjak.config.tls.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.tornjak.config.tls.service.type }}
+  selector:
+   {{- include "spire-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ include "spire-tornjak.backend" . }}-tls
+      port: {{ .Values.tornjak.config.tls.service.port }}
+      targetPort: tornjak-tls
+      protocol: TCP
+{{- end }}
+{{- if eq (.Values.tornjak.config.mtls.enabled | toString) "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ include "spire-server.namespace" . }}
+  name: {{ include "spire-tornjak.backend" . }}-mtls
+  {{- with .Values.tornjak.config.mtls.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.tornjak.config.mtls.service.type }}
+  selector:
+   {{- include "spire-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ include "spire-tornjak.backend" . }}-mtls
+      port: {{ .Values.tornjak.config.mtls.service.port }}
+      targetPort: tornjak-mtls
+      protocol: TCP
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -389,8 +389,9 @@ tornjak:
 
     # Tornjak TLS service
     tls:
-      # -- Enables Tornjak TLS service
-      enabled: true
+      # -- Enables Tornjak TLS service. When 'true', the 'serverSecret'
+      # must be created prior to installing this chart
+      enabled: false
       # -- Container port value for TLS
       port: 20000
       # -- Service to handle Tornjak TLS connection
@@ -401,8 +402,9 @@ tornjak:
 
     # Tornjak mTLS service
     mtls:
-      # -- Enables Tornjak TLS service
-      enabled: true
+      # -- Enables Tornjak TLS service. When 'true', the 'serverSecret'
+      # and 'userSecret' must be created prior to installing this chart
+      enabled: false
       # -- Container port value for mTLS
       port: 30000
       # -- Service to handle Tornjak mTLS connection

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -360,6 +360,12 @@ tornjak:
     # -- Overrides the image tag
     tag: "v1.2.2"
 
+  service:
+    type: ClusterIP
+    portHttp: 10080
+    portHttps: 10443
+    annotations: {}
+
   startupProbe:
     failureThreshold: 3
     # -- Initial delay seconds for
@@ -389,12 +395,6 @@ tornjak:
       # (required for `mtls` connectionType)
       type: Secret
       name: tornjak-user-ca
-
-  service:
-    type: ClusterIP
-    portHttp: 10080
-    portHttps: 10443
-    annotations: {}
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -392,7 +392,8 @@ tornjak:
     # -- Enables the service for a given `connectionType`
     service:
       type: ClusterIP
-      port: 10000
+      portHttp: 10080
+      portHttps: 10443
       annotations: {}
 
   resources: {}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -390,12 +390,11 @@ tornjak:
       type: Secret
       name: tornjak-user-ca
 
-    # -- Enables the service for a given `connectionType`
-    service:
-      type: ClusterIP
-      portHttp: 10080
-      portHttps: 10443
-      annotations: {}
+  service:
+    type: ClusterIP
+    portHttp: 10080
+    portHttps: 10443
+    annotations: {}
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -390,13 +390,9 @@ tornjak:
     # Tornjak TLS service
     tls:
       # -- Enables Tornjak TLS service
-      enabled: false
+      enabled: true
       # -- Container port value for TLS
       port: 20000
-      # -- Certificate for TLS connection
-      cert: "/opt/spire/sample-keys/cert.pem"
-      # -- Key for TLS connection
-      key:  "/opt/spire/sample-keys/key.pem"
       # -- Service to handle Tornjak TLS connection
       service:
         type: ClusterIP
@@ -406,20 +402,18 @@ tornjak:
     # Tornjak mTLS service
     mtls:
       # -- Enables Tornjak TLS service
-      enabled: false
+      enabled: true
       # -- Container port value for mTLS
       port: 30000
-      # -- Certificate for mTLS connection
-      cert: "/opt/spire/sample-keys/cert.pem"
-      # -- Key for mTLS connection
-      key:  "/opt/spire/sample-keys/key.pem"
-      # -- CA for mTLS connection
-      ca: "/opt/spire/sample-keys/rootCA.pem"
       # -- Service to handle Tornjak mTLS connection
       service:
         type: ClusterIP
         port: 30000
         annotations: {}
+    # -- Name of the secret containing server side key and certificate for TLS verification
+    serverSecret: tornjak-server-secret
+    # -- Name of the secret containing user CA for mTLS verification
+    userSecret: tornjak-user-secret
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -390,7 +390,7 @@ tornjak:
     # Tornjak TLS service
     tls:
       # -- Enables Tornjak TLS service
-      enabled: true
+      enabled: false
       # -- Container port value for TLS
       port: 20000
       # -- Certificate for TLS connection
@@ -406,7 +406,7 @@ tornjak:
     # Tornjak mTLS service
     mtls:
       # -- Enables Tornjak TLS service
-      enabled: true
+      enabled: false
       # -- Container port value for mTLS
       port: 30000
       # -- Certificate for mTLS connection

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -381,10 +381,13 @@ tornjak:
 
     # -- Name of the secret containing server side key and certificate for TLS verification
     # (required for `tls` or `mtls` connectionType)
-    serverSecret: tornjak-server-secret
-    # -- Name of the secret containing user CA for mTLS verification
-    # (required for `mtls` connectionType)
-    userSecret: tornjak-user-secret
+    tlsSecret: tornjak-tls-secret
+    userCA:
+      # -- Type of delivery for the user CA for mTLS client verification
+      # options are `Secret` or `ConfigMap`
+      # (required for `mtls` connectionType)
+      type: Secret
+      name: tornjak-user-ca
 
     # -- Enables the service for a given `connectionType`
     service:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -375,9 +375,10 @@ tornjak:
       driver: "sqlite3"
       file: "/run/spire/data/tornjak.sqlite3"
 
-    # -- Tornjak supports 3 connection types: `http`, `tls`, and `mtls`.
-    # Select only one.
-    connectionType: http
+    # Tornjak supports 3 connection types: `http`, `tls`, and `mtls`.
+    # When `tlsSecret` is created in this chart namespace, the TLS connection is started
+    # When `tlsSecret` and `userCa.tornjak-user-ca` are created in this chart namespace, the mTLS connection is started
+    # When none of them are created, Tornjak starts with HTTP connection only
 
     # -- Name of the secret containing server side key and certificate for TLS verification
     # (required for `tls` or `mtls` connectionType)

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -375,47 +375,23 @@ tornjak:
       driver: "sqlite3"
       file: "/run/spire/data/tornjak.sqlite3"
 
-    # Tornjak HTTP service
-    http:
-      # -- Enables Tornjak HTTP (insecure) service
-      enabled: true
-      # -- Container port value for HTTP
-      port: 10000
-      # -- Service to handle Tornjak HTTP connection
-      service:
-        type: ClusterIP
-        port: 10000
-        annotations: {}
+    # -- Tornjak supports 3 connection types: `http`, `tls`, and `mtls`.
+    # Select only one.
+    connectionType: http
 
-    # Tornjak TLS service
-    tls:
-      # -- Enables Tornjak TLS service. When 'true', the 'serverSecret'
-      # must be created prior to installing this chart
-      enabled: false
-      # -- Container port value for TLS
-      port: 20000
-      # -- Service to handle Tornjak TLS connection
-      service:
-        type: ClusterIP
-        port: 20000
-        annotations: {}
-
-    # Tornjak mTLS service
-    mtls:
-      # -- Enables Tornjak TLS service. When 'true', the 'serverSecret'
-      # and 'userSecret' must be created prior to installing this chart
-      enabled: false
-      # -- Container port value for mTLS
-      port: 30000
-      # -- Service to handle Tornjak mTLS connection
-      service:
-        type: ClusterIP
-        port: 30000
-        annotations: {}
     # -- Name of the secret containing server side key and certificate for TLS verification
+    # (required for `tls` or `mtls` connectionType)
     serverSecret: tornjak-server-secret
     # -- Name of the secret containing user CA for mTLS verification
+    # (required for `mtls` connectionType)
     userSecret: tornjak-user-secret
+
+    # -- Enables the service for a given `connectionType`
+    service:
+      type: ClusterIP
+      port: 10000
+      annotations: {}
+
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -392,7 +392,6 @@ tornjak:
       port: 10000
       annotations: {}
 
-
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -344,7 +344,7 @@ nodeAttestor:
     enabled: true
     serviceAccountAllowList: []
 
-# tornjak - Tornjak specific configuration
+# tornjak - Tornjak default values
 tornjak:
   # -- Deploys Tornjak API (backend) (Not for production)
   enabled: false
@@ -359,10 +359,6 @@ tornjak:
     version: ""
     # -- Overrides the image tag
     tag: "v1.2.2"
-  service:
-    type: ClusterIP
-    port: 10000
-    annotations: {}
 
   startupProbe:
     failureThreshold: 3
@@ -372,11 +368,59 @@ tornjak:
     successThreshold: 1
     timeoutSeconds: 5
 
+  # tornjak - Tornjak specific configuration
   config:
-    # -- persistent DB for storing Tornjak specific information
+    # -- Persistent DB for storing Tornjak specific information
     dataStore:
       driver: "sqlite3"
       file: "/run/spire/data/tornjak.sqlite3"
+
+    # Tornjak HTTP service
+    http:
+      # -- Enables Tornjak HTTP (insecure) service
+      enabled: true
+      # -- Container port value for HTTP
+      port: 10000
+      # -- Service to handle Tornjak HTTP connection
+      service:
+        type: ClusterIP
+        port: 10000
+        annotations: {}
+
+    # Tornjak TLS service
+    tls:
+      # -- Enables Tornjak TLS service
+      enabled: true
+      # -- Container port value for TLS
+      port: 20000
+      # -- Certificate for TLS connection
+      cert: "/opt/spire/sample-keys/cert.pem"
+      # -- Key for TLS connection
+      key:  "/opt/spire/sample-keys/key.pem"
+      # -- Service to handle Tornjak TLS connection
+      service:
+        type: ClusterIP
+        port: 20000
+        annotations: {}
+
+    # Tornjak mTLS service
+    mtls:
+      # -- Enables Tornjak TLS service
+      enabled: true
+      # -- Container port value for mTLS
+      port: 30000
+      # -- Certificate for mTLS connection
+      cert: "/opt/spire/sample-keys/cert.pem"
+      # -- Key for mTLS connection
+      key:  "/opt/spire/sample-keys/key.pem"
+      # -- CA for mTLS connection
+      ca: "/opt/spire/sample-keys/rootCA.pem"
+      # -- Service to handle Tornjak mTLS connection
+      service:
+        type: ClusterIP
+        port: 30000
+        annotations: {}
+
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -374,7 +374,7 @@ tornjak:
     successThreshold: 1
     timeoutSeconds: 5
 
-  # tornjak - Tornjak specific configuration
+  # tornjak - Tornjak default values
   config:
     # -- Persistent DB for storing Tornjak specific information
     dataStore:
@@ -382,6 +382,7 @@ tornjak:
       file: "/run/spire/data/tornjak.sqlite3"
 
     # Tornjak supports 3 connection types: `http`, `tls`, and `mtls`.
+    # The connections are determined based on provided configuration
     # When `tlsSecret` is created in this chart namespace, the TLS connection is started
     # When `tlsSecret` and `userCa.tornjak-user-ca` are created in this chart namespace, the mTLS connection is started
     # When none of them are created, Tornjak starts with HTTP connection only

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -21,13 +21,20 @@ A Helm chart to deploy Tornjak frontend
 | Tornjak    | `1.0.x`            |
 | Helm       | `3.x`              |
 
+## Tornjak
+
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak) and it is composed of two components:
+
+* [Backend](../spire-server/README.md) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
+* Frontend (this chart) - Tornjak UI
+
 ## Prerequisites
 
 This chart requires access to Tornjak Backend (`tornjakFrontend.apiServerURL`).
 This URL needs to be reachable from your web browser and can therefore not be a cluster internal URL.
 
 Obtain the URL for Tornjak APIs. If deployed in the same cluster, locally,
-Tornjak APIs are typically available at `http://localhost:10000`.
+Tornjak APIs are typically available at `http://localhost:10080`.
 Review Tornjak documentation for more details.
 
 ## Usage

--- a/charts/spire/charts/tornjak-frontend/README.md.gotmpl
+++ b/charts/spire/charts/tornjak-frontend/README.md.gotmpl
@@ -23,13 +23,20 @@
 | Tornjak    | `1.0.x`            |
 | Helm       | `3.x`              |
 
+## Tornjak
+
+Tornjak is the UI and Control Plane for SPIRE [https://github.com/spiffe/tornjak](https://github.com/spiffe/tornjak) and it is composed of two components:
+
+* [Backend](../spire-server/README.md) - Tornjak APIs that extend SPIRE APIs with Control Plane functionality
+* Frontend (this chart) - Tornjak UI
+
 ## Prerequisites
 
 This chart requires access to Tornjak Backend (`tornjakFrontend.apiServerURL`).
 This URL needs to be reachable from your web browser and can therefore not be a cluster internal URL.
 
 Obtain the URL for Tornjak APIs. If deployed in the same cluster, locally,
-Tornjak APIs are typically available at `http://localhost:10000`.
+Tornjak APIs are typically available at `http://localhost:10080`.
 Review Tornjak documentation for more details.
 
 ## Usage


### PR DESCRIPTION
This PR adds TLS and mTLS connection to Tornjak backend. It is assumed users create secret `tornjak-certs` prior to deploying the helm charts when TLS and/or mTLS are enabled. 

Sample secret (to be documented): 
```
kubectl -n spire-server create secret generic tornjak-certs \
--from-file=key.pem="client.key"  \
--from-file=cert.pem="client.crt" \
--from-file=rootCA.pem="CA/rootCA.crt"

# testing TLS: 
curl --cacert CA/rootCA.crt https://localhost:20000/

# testing mTLS: 
curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhost:30000
```