### PR TITLE
Update upstream-ca-secret.yaml

### DIFF
--- a/charts/spire/charts/spire-server/templates/upstream-ca-secret.yaml
+++ b/charts/spire/charts/spire-server/templates/upstream-ca-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "spire-server.upstream-ca-secret" $root }}
-  namespace: {{ include "spire-server.namespace" . }}
+  namespace: {{ include "spire-server.namespace" $root }}
   labels:
     {{- include "spire-server.labels" $root | nindent 4 }}
 data:


### PR DESCRIPTION
Fix an issue with nested context being used for namespace

Fixes this issue:
```
Error: UPGRADE FAILED: template: spire/charts/spire-server/templates/upstream-ca-secret.yaml:8:16: executing "spire/charts/spire-server/templates/upstream-ca-secret.yaml" at <include "spire-server.names
pace" .>: error calling include: template: spire/charts/spire-server/templates/_helpers.tpl:30:16: executing "spire-server.namespace" at <.Values.namespaceOverride>: nil pointer evaluating interface {}.
namespaceOverride
helm.go:84: [debug] template: spire/charts/spire-server/templates/upstream-ca-secret.yaml:8:16: executing "spire/charts/spire-server/templates/upstream-ca-secret.yaml" at <include "spire-server.namespac
e" .>: error calling include: template: spire/charts/spire-server/templates/_helpers.tpl:30:16: executing "spire-server.namespace" at <.Values.namespaceOverride>: nil pointer evaluating interface {}.nam
espaceOverride
```