### PR TITLE
Dropping k8s versions in CI older than 3, as per readme

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -139,9 +139,6 @@ jobs:
           - v1.27.2
           - v1.26.4
           - v1.25.9
-          - v1.24.13
-          - v1.23.17
-          - v1.22.17
         values:
           - ${{ fromJson(needs.build-matrix.outputs.tests) }}
 
@@ -170,7 +167,7 @@ jobs:
         uses: helm/kind-action@v1.7.0
         # Only build a kind cluster if there are chart changes to test.
         with:
-          version: v0.18.0
+          version: v0.19.0
           node_image: kindest/node:${{ matrix.k8s }}
           config: .github/kind/conf/kind-config.yaml
           verbosity: 1


### PR DESCRIPTION
PRs run 86 tests, this should significantly cut down on that.
correction 125 tests

<img width="166" alt="image" src="https://github.com/spiffe/helm-charts/assets/239123/ab380a52-627e-45bb-af8e-f2b6afc800d8">
