### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 .idea/
 *.swp
 charts/**/*.tgz
+.DS_Store


### PR DESCRIPTION
Macs create these files in every directory.