### PR TITLE
Add configmap annotation to spire-bundle configmap

### DIFF
--- a/charts/spire/charts/spire-server/templates/bundle-configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/bundle-configmap.yaml
@@ -4,3 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "spire-lib.bundle-configmap" . }}
   namespace: {{ .Values.notifier.k8sbundle.namespace | default $namespace }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}


### PR DESCRIPTION
In PR https://github.com/spiffe/helm-charts/pull/272 I added support for configmaps to be annotated. This is needed to deploy with spinnaker. I forgot to add the annotation to the spire-bundle configmap. This pr fills that gap.