### PR TITLE
Always add parseTime=true for mysql query string

### DIFF
--- a/.github/tests/production-external-mysql/install.sh
+++ b/.github/tests/production-external-mysql/install.sh
@@ -29,8 +29,6 @@ spire-server:
       password: ${DBPW}
       host: mysql
       port: 3306
-      options:
-      - parseTime: true
 EOF
 
 helm install mysql mysql --namespace "spire-server" --version "$VERSION_MYSQL" --repo "$HELM_REPO_MYSQL" \

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -115,7 +115,7 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 {{- $lst = append $lst "parseTime=true" }}
-{{- printf "?%s" (join "&" $lst) }}
+{{- printf "?%s" (join "&" (uniq $lst)) }}
 {{- end }}
 
 {{- define "spire-server.config-postgresql-options" }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -114,9 +114,8 @@ Create the name of the service account to use
 {{- $lst = append $lst $entry }}
 {{- end }}
 {{- end }}
-{{- if gt (len $lst) 0 }}
+{{- $lst = append $lst "parseTime=true" }}
 {{- printf "?%s" (join "&" $lst) }}
-{{- end }}
 {{- end }}
 
 {{- define "spire-server.config-postgresql-options" }}

--- a/examples/external-mysql/values.yaml
+++ b/examples/external-mysql/values.yaml
@@ -6,5 +6,3 @@ spire-server:
       host: mysql
       port: 3306
       username: spire
-      options:
-        - parseTime: true


### PR DESCRIPTION
If `parseTime=true` is not present [spire server will error](https://github.com/spiffe/spire/blob/f483d76f0935736e2604a8dc3d74fcce0bbb3666/pkg/server/datastore/sqlstore/mysql.go#L146-L148). This pr ensures that it is always present when mysql db is used, rather than leaving it to use to add it to `options:`.