### PR TITLE
Implement pre-delete hook for graceful delete of spiffe-oidc-discovery-provider

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -219,6 +219,11 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-oidc-discovery-provider.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spiffe-oidc-discovery-provider |
 | spiffe-oidc-discovery-provider.telemetry.prometheus.port | int | `9988` |  |
 | spiffe-oidc-discovery-provider.tolerations | list | `[]` |  |
+| spiffe-oidc-discovery-provider.tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spiffe-oidc-discovery-provider.tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| spiffe-oidc-discovery-provider.tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| spiffe-oidc-discovery-provider.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
+| spiffe-oidc-discovery-provider.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 | spire-agent.bundleConfigMap | string | `"spire-bundle"` |  |
 | spire-agent.clusterName | string | `"example-cluster"` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -96,6 +96,11 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spiffe-oidc-discovery-provider |
 | telemetry.prometheus.port | int | `9988` |  |
 | tolerations | list | `[]` |  |
+| tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| tools.kubectl.image.tag | string | `""` | Overrides the image tag |
+| tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/_helpers.tpl
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/_helpers.tpl
@@ -85,4 +85,3 @@ Create the name of the service account to use
 {{- define "spiffe-oidc-discovery-provider.workload-api-socket-path" -}}
 {{- printf "/spiffe-workload-api/%s" .Values.agentSocketName }}
 {{- end }}
-

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spiffe-oidc-discovery-provider.serviceAccountName" . }}-pre-delete
+  namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
+  labels:
+    {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: [{{ include "spiffe-oidc-discovery-provider.fullname" . | quote }}]
+    verbs: ["get", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spiffe-oidc-discovery-provider.serviceAccountName" . }}-pre-delete
+    namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
+roleRef:
+  kind: Role
+  name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}-pre-delete
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}-pre-delete
+  namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
+  labels:
+    {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}-pre-delete
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "spiffe-oidc-discovery-provider.serviceAccountName" . }}-pre-delete
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: pre-delete-job
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        image: {{ template "spire-lib.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        args:
+          - delete
+          - -n
+          - {{ include "spiffe-oidc-discovery-provider.namespace" . }}
+          - deployment
+          - {{ include "spiffe-oidc-discovery-provider.fullname" . }}
+          - --wait

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -215,3 +215,17 @@ tests:
       version: ""
       # -- Overrides the image tag
       tag: 5.2.15
+
+tools:
+  kubectl:
+    image:
+      # -- The OCI registry to pull the image from
+      registry: docker.io
+      # -- The repository within the registry
+      repository: rancher/kubectl
+      # -- The image pull policy
+      pullPolicy: IfNotPresent
+      # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+      version: ""
+      # -- Overrides the image tag
+      tag: ""

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -105,15 +105,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "spire-server.kubectl-image" }}
-{{- $root := deepCopy . }}
-{{- $tag := (default $root.image.tag $root.image.version) | toString }}
-{{- if eq (len $tag) 0 }}
-{{- $_ := set $root.image "tag" (regexReplaceAll "^(v?\\d+\\.\\d+\\.\\d+).*" $root.KubeVersion "${1}") }}
-{{- end }}
-{{- include "spire-lib.image" $root }}
-{{- end }}
-
 {{- define "spire-server.config-mysql-query" }}
 {{- $lst := list }}
 {{- range . }}

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -63,7 +63,7 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-lib.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -56,14 +56,14 @@ spec:
       name: {{ include "spire-server.fullname" . }}-post-upgrade
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-upgrade 
+      serviceAccountName: {{ include "spire-server.serviceAccountName" . }}-post-upgrade
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: post-upgrade-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-lib.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -63,7 +63,7 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-lib.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -90,3 +90,12 @@ rules:
         {{- end }}
   {{- end }}
 {{- end }}
+
+{{- define "spire-lib.kubectl-image" }}
+{{- $root := deepCopy . }}
+{{- $tag := (default $root.image.tag $root.image.version) | toString }}
+{{- if eq (len $tag) 0 }}
+{{- $_ := set $root.image "tag" (regexReplaceAll "^(v?\\d+\\.\\d+\\.\\d+).*" $root.KubeVersion "${1}") }}
+{{- end }}
+{{- include "spire-lib.image" $root }}
+{{- end }}


### PR DESCRIPTION
Resolves #330 

You can test by installing the chart and then uninstalling the chart.

When you watch the pods, you will see the oidc pod being removed first solving the csi-driver issue.