### PR TITLE
Allow contributors to run linting easily on local

### DIFF
--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -94,9 +94,7 @@ jobs:
           version: ${{ env.CHART_TESTING_VERSION }}
 
       - name: Run chart-testing (lint)
-        run: |
-          ct lint --debug ${{ github.base_ref != 'release' && '--check-version-increment=false' || '' }} \
-            --target-branch ${{ github.base_ref }}
+        run: TARGET_BRANCH=${{ github.base_ref }} make lint${{ github.base_ref == 'release' && '-release' || '' }}
 
     outputs:
       changed: ${{ steps.list-changed.outputs.changed }}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
+TARGET_BRANCH ?= main
+
 .PHONY: help
 help: ## Display this help.
 	@$(MAKE) help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Linting:
+
+.PHONY: lint
+lint: ## Lint the charts using chart-testing
+	@echo Linting charts…
+	@ct lint --config ct.yaml --target-branch $(TARGET_BRANCH) --check-version-increment=false
+
+lint-release: ## Lint the charts using chart-testing for release
+	@echo Linting charts…
+	@ct lint --config ct.yaml --target-branch $(TARGET_BRANCH)
 
 ##@ Testing:
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,11 @@
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+chart-repos:
+  - spiffe=https://spiffe.github.io/helm-charts/
+  - bitnami=https://charts.bitnami.com/bitnami
+  - ingress-nginx=https://kubernetes.github.io/ingress-nginx
+exclude-deprecated: true
+debug: true
+helm-extra-args: "--timeout 15m"


### PR DESCRIPTION
This gives contributors an easy way to lint the chars locally using `chart-testing` so they won't have surprises when creating a PR.

```shell
make lint
```
