### PR TITLE
Bump spire Helm Chart version from 0.8.1 to 0.9.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.8.1
+version: 0.9.0
 appVersion: "1.7.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* 57a9320 Add SPIRE 1.7.0 to main readme (#357)
* af36f7c Align the bash image version with other instances for spire-agent (#356)
* c11a8c0 Implement pre-delete hook for graceful delete of spiffe-oidc-discovery-provider (#353)
* a6dcf26 Allow for SPIRE Agent to run as non root user (#209)
* 9cf6049 Allow contributors to run linting easily on local
* e88f7f6 Add configmap annotation to spire-bundle configmap (#351)
* 020bde8 Add support to create a issuer and CA via cert-manager (#342)
* 9d504de Ignore .DS_Store files
* e6b608c Bump spire images to 1.7.0 (#348)
* c97a788 Fix bundle role/rolebinding naming conflict (#333)
* b66077e Bump peter-evans/create-pull-request from 5.0.1 to 5.0.2 (#349)
* d0da864 Add missing metadata to subcharts (#347)
* 4c0a1d5 Allow overriding test images (#186)
* 250fd5d Add missing global values to charts (#311)
* 5d8c907 Dropping k8s versions in CI older than 3, as per readme (#344)
* 8748933 Update upstream-ca-secret.yaml (#341)
* 4e07450 Fix ingress annotations for federation (#337)
* ea09199 Bump actions/checkout from 3.5.0 to 3.5.3
* 87fe198 Merge pull request #331 from edwbuck/key_conventions
* ddc0166 Fix line wrapping.
* 0cae9ce Update project/conventions.md
* 52e5c24 Upgrade Tornjak to image v1.2.2 (#328)
* 28e2abf Choose a different example for dotted Acronyms.
* d60d68c Added accidentally clipped explicit name guidelines.
* f6a7b62 Update project/conventions.md
* cfa9f78 Bump test chart dependencies (#332)
* c3213ab Initial submission of Helm Chart key naming conventions.
* 28c0824 Bump test chart dependencies (#322)
* d333154 Add Makefile for local testing (#327)
* 9fa1ec2 Improve Tornjak backend test (#321)
* 5b779dc Improve Tornjak frontend test (#320)
