### PR TITLE
add missing federatesWith option

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -300,6 +300,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.enabled | bool | `false` |  |
 | spire-server.controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | spire-server.controllerManager.identities.enabled | bool | `true` |  |
+| spire-server.controllerManager.identities.federatesWith | list | `[]` |  |
 | spire-server.controllerManager.identities.namespaceSelector | object | `{}` |  |
 | spire-server.controllerManager.identities.podSelector | object | `{}` |  |
 | spire-server.controllerManager.identities.spiffeIDTemplate | string | `"spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -50,6 +50,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.enabled | bool | `false` |  |
 | controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | controllerManager.identities.enabled | bool | `true` |  |
+| controllerManager.identities.federatesWith | list | `[]` |  |
 | controllerManager.identities.namespaceSelector | object | `{}` |  |
 | controllerManager.identities.podSelector | object | `{}` |  |
 | controllerManager.identities.spiffeIDTemplate | string | `"spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"` |  |

--- a/charts/spire/charts/spire-server/templates/controller-manager-cluster-ids.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-cluster-ids.yaml
@@ -8,6 +8,10 @@ metadata:
   namespace: {{ include "spire-server.namespace" $root }}
 spec:
   spiffeIDTemplate: {{ .identities.spiffeIDTemplate | quote }}
+  {{- with .identities.federatesWith }}
+  federatesWith:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .identities.podSelector }}
   podSelector:
     {{- toYaml . | nindent 4 }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -279,6 +279,9 @@ controllerManager:
       #   spiffe.io/spiffe-id: "true"
     dnsNameTemplates: []
       # - '{{ index .PodMeta.Labels "app.kubernetes.io/name" }}.{{ .PodMeta.Namespace }}.svc.cluster.local'
+    federatesWith: []
+    # - example.io
+    # - example.ai
 
   validatingWebhookConfiguration:
     failurePolicy: Fail


### PR DESCRIPTION
DEMO

```
spire-server-0 -- spire-server entry show -spiffeID spiffe://box-4.example.com/ns/dwells/sa/dwells-rc-realm-client
Defaulted container "spire-server" out of: spire-server, spire-controller-manager, wait (init)
Found 1 entry
Entry ID         : 09301666-010e-4ba9-9dcb-44370d4e49e4
SPIFFE ID        : spiffe://box-4.example.com/ns/dwells/sa/dwells-rc-realm-client
Parent ID        : spiffe://box-4.example.com/spire/agent/k8s_psat/example-cluster/ff93872d-791f-4bf3-a532-475775d03d3e
Revision         : 0
X509-SVID TTL    : default
JWT-SVID TTL     : default
Selector         : k8s:pod-uid:40e0bcad-6ec8-460b-a839-659654549d7a
FederatesWith    : box-3.example.com
```