### PR TITLE
Bump spire-controller-manager from 0.2.2 to 0.2.3

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -310,7 +310,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| spire-server.controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
+| spire-server.controllerManager.image.tag | string | `"0.2.3"` | Overrides the image tag |
 | spire-server.controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -60,7 +60,7 @@ A Helm chart to install the SPIRE server.
 | controllerManager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | controllerManager.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
-| controllerManager.image.tag | string | `"0.2.2"` | Overrides the image tag |
+| controllerManager.image.tag | string | `"0.2.3"` | Overrides the image tag |
 | controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -231,7 +231,7 @@ controllerManager:
     # -- This value is deprecated in favor of tag. (Will be removed in a future release)
     version: ""
     # -- Overrides the image tag
-    tag: "0.2.2"
+    tag: "0.2.3"
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
resolves a bunch of vulnerabilities in the Image

Signed-off-by: Marco Franssen <marco.franssen@gmail.com>
