### PR TITLE
Ensure the released OCI artifact is also captured in rekor

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -66,3 +66,5 @@ jobs:
             digest="$(awk -F "[, ]+" '/Digest/{print $NF}' < .digest)"
             cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/helm-charts/"${name}"@"${digest}"
           done
+        env:
+          COSIGN_YES: true


### PR DESCRIPTION
This setting auto confirms the dialog to upload the signature in the Rekor
transparancy log. This allows consumers of the oci release to verify the
signature by using the rekor transparancy log.
