### PR TITLE
Fix bug in cert-manager upstream authority

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -78,7 +78,7 @@ plugins:
   UpstreamAuthority:
     - cert-manager:
         plugin_data:
-          issuer_name: {{ default .issuer_name (include "spire-server.fullname" $root) }}
+          issuer_name: {{ default (include "spire-server.fullname" $root) .issuer_name }}
           issuer_kind: {{ .issuer_kind | quote }}
           issuer_group: {{ .issuer_group | quote }}
           namespace: {{ default $root.Release.Namespace .namespace | quote }}


### PR DESCRIPTION
The arguments for default function need to be the other way around

Signed-off-by: Marco Franssen <marco.franssen@gmail.com>
