### PR TITLE
Fix missing spiffe-csi-driver imagePullSecrets template

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         {{- include "spiffe-csi-driver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "spiffe-csi-driver.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The spiffe-csi-driver sub-chart describes in its `README.md` that it supports an `imagePullSecret` value, however the helm templating functionality is missing in the `daemonset.yaml`.

The following PR adds the missing functionality, replicated using existing logic in other sub-charts.