### PR TITLE
Add missing tolerations config to daemonsets

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -153,6 +153,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-csi-driver.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | spiffe-csi-driver.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | spiffe-csi-driver.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| spiffe-csi-driver.tolerations | list | `[]` |  |
 | spiffe-oidc-discovery-provider.affinity | object | `{}` |  |
 | spiffe-oidc-discovery-provider.agentSocketName | string | `"spire-agent.sock"` | The name of the spire-agent unix socket |
 | spiffe-oidc-discovery-provider.autoscaling.enabled | bool | `false` |  |
@@ -272,6 +273,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-agent.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | spire-agent.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-agent |
 | spire-agent.telemetry.prometheus.port | int | `9988` |  |
+| spire-agent.tolerations | list | `[]` |  |
 | spire-agent.trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | spire-agent.trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
 | spire-agent.trustDomain | string | `"example.org"` | The trust domain to be used for the SPIFFE identifiers |

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -59,5 +59,6 @@ A Helm chart to install the SPIFFE CSI driver.
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -66,6 +66,8 @@ securityContext:
 
 nodeSelector: {}
 
+tolerations: []
+
 nodeDriverRegistrar:
   image:
     # -- The OCI registry to pull the image from

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -75,6 +75,7 @@ A Helm chart to install the SPIRE agent.
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-agent |
 | telemetry.prometheus.port | int | `9988` |  |
+| tolerations | list | `[]` |  |
 | trustBundleFormat | string | `"pem"` | If using trustBundleURL, what format is the url. Choices are "pem" and "spiffe" |
 | trustBundleURL | string | `""` | If set, obtain trust bundle from url instead of Kubernetes ConfigMap |
 | trustDomain | string | `"example.org"` | The trust domain to be used for the SPIFFE identifiers |

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -110,6 +110,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: spire-config
           configMap:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -62,6 +62,8 @@ resources: {}
 
 nodeSelector: {}
 
+tolerations: []
+
 # -- The log level, valid values are "debug", "info", "warn", and "error"
 logLevel: info
 # -- The name of the Kubernetes cluster (`kubeadm init --service-dns-domain`)


### PR DESCRIPTION
spiffe-csi-driver and spire-agent are missing the ability to specify tolerations. This PR adds the missing functionality.

fixes: https://github.com/spiffe/helm-charts/issues/380