### PR TITLE
Bump spire Helm Chart version from 0.10.1 to 0.11.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: "1.7.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied. 

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* 94a2b723 Merge pull request #324 from spiffe/enable-testing-multiple-charts
* e426bc06 Downgrade chart-testing tool to 3.8.0
* 09b46646 Utilize ct install --github-groups in ci workflow
* 42086bd6 Run example tests also on all k8s versions
* 4848c48b Improve Makefile help and implementation
* db060382 Increase some timeouts, trying to fix the tests
* 54ed71f9 Add back tests for examples
* 4b4cef1e Skip namespace-override test because of #330
* 380979c7 Prevent ci folder ending up in Helm package
* 06ddb7cd Use chart-testing ci/*-values.yaml for testing
* a4c1de7b Add basic unit test framework (#390)
* 088b2960 Improve tornjak service API to have object structure (#392)
* 522066e9 Align tornjak clientCA naming convention (#393)
* f05cb4fe Add option to configure TLS/mTLS endpoint for Tornjak (#338)
* f461a017 Bump test chart dependencies (#386)
* ce39e827 Bump test chart dependencies (#382)
* 19d32087 Fix oidc provider config change not rolling out (#383)
* 0197621f Bump helm/kind-action from 1.7.0 to 1.8.0 (#384)
* 3ed1859c Add missing tolerations config to daemonsets (#381)
* 4ad68b15 Add namespace to spiffe-oidc-discovery-provider RBAC definitions (#379)
* c1b1dd3d Add additional domains to JWT issued items. (#230)
* 3405e139 Bump test chart dependencies
* 81452d5e Fix missing spiffe-csi-driver imagePullSecrets template (#376)
