### PR TITLE
Add aws_pca to the spire-server

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -418,6 +418,14 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.startupProbe.successThreshold | int | `1` |  |
 | spire-server.tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | spire-server.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| spire-server.upstreamAuthority.awspca.assume_role_arn | Optional | `""` | ARN of an IAM role to assume |
+| spire-server.upstreamAuthority.awspca.ca_signing_template_arn | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
+| spire-server.upstreamAuthority.awspca.certificate_authority_arn | string | `""` | ARN of the "upstream" CA certificate |
+| spire-server.upstreamAuthority.awspca.enabled | bool | `false` |  |
+| spire-server.upstreamAuthority.awspca.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
+| spire-server.upstreamAuthority.awspca.region | string | `""` | AWS Region to use |
+| spire-server.upstreamAuthority.awspca.signing_algorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
+| spire-server.upstreamAuthority.awspca.supplemental_bundle_path | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
 | spire-server.upstreamAuthority.certManager.ca.create | bool | `false` | Creates a Cert-Manager CA |
 | spire-server.upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
 | spire-server.upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -418,14 +418,14 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.startupProbe.successThreshold | int | `1` |  |
 | spire-server.tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | spire-server.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| spire-server.upstreamAuthority.awspca.assume_role_arn | Optional | `""` | ARN of an IAM role to assume |
-| spire-server.upstreamAuthority.awspca.ca_signing_template_arn | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
-| spire-server.upstreamAuthority.awspca.certificate_authority_arn | string | `""` | ARN of the "upstream" CA certificate |
-| spire-server.upstreamAuthority.awspca.enabled | bool | `false` |  |
-| spire-server.upstreamAuthority.awspca.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
-| spire-server.upstreamAuthority.awspca.region | string | `""` | AWS Region to use |
-| spire-server.upstreamAuthority.awspca.signing_algorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
-| spire-server.upstreamAuthority.awspca.supplemental_bundle_path | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
+| spire-server.upstreamAuthority.awsPCA.assumeRoleARN | Optional | `""` | ARN of an IAM role to assume |
+| spire-server.upstreamAuthority.awsPCA.caSigningTemplateARN | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
+| spire-server.upstreamAuthority.awsPCA.certificateAuthorityARN | string | `""` | ARN of the "upstream" CA certificate |
+| spire-server.upstreamAuthority.awsPCA.enabled | bool | `false` |  |
+| spire-server.upstreamAuthority.awsPCA.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
+| spire-server.upstreamAuthority.awsPCA.region | string | `""` | AWS Region to use |
+| spire-server.upstreamAuthority.awsPCA.signingAlgorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
+| spire-server.upstreamAuthority.awsPCA.supplementalBundlePath | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
 | spire-server.upstreamAuthority.certManager.ca.create | bool | `false` | Creates a Cert-Manager CA |
 | spire-server.upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
 | spire-server.upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -218,6 +218,14 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tornjak.startupProbe.successThreshold | int | `1` |  |
 | tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| upstreamAuthority.awspca.assume_role_arn | Optional | `""` | ARN of an IAM role to assume |
+| upstreamAuthority.awspca.ca_signing_template_arn | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
+| upstreamAuthority.awspca.certificate_authority_arn | string | `""` | ARN of the "upstream" CA certificate |
+| upstreamAuthority.awspca.enabled | bool | `false` |  |
+| upstreamAuthority.awspca.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
+| upstreamAuthority.awspca.region | string | `""` | AWS Region to use |
+| upstreamAuthority.awspca.signing_algorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
+| upstreamAuthority.awspca.supplemental_bundle_path | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
 | upstreamAuthority.certManager.ca.create | bool | `false` | Creates a Cert-Manager CA |
 | upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
 | upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -218,14 +218,14 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tornjak.startupProbe.successThreshold | int | `1` |  |
 | tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| upstreamAuthority.awspca.assume_role_arn | Optional | `""` | ARN of an IAM role to assume |
-| upstreamAuthority.awspca.ca_signing_template_arn | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
-| upstreamAuthority.awspca.certificate_authority_arn | string | `""` | ARN of the "upstream" CA certificate |
-| upstreamAuthority.awspca.enabled | bool | `false` |  |
-| upstreamAuthority.awspca.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
-| upstreamAuthority.awspca.region | string | `""` | AWS Region to use |
-| upstreamAuthority.awspca.signing_algorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
-| upstreamAuthority.awspca.supplemental_bundle_path | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
+| upstreamAuthority.awsPCA.assumeRoleARN | Optional | `""` | ARN of an IAM role to assume |
+| upstreamAuthority.awsPCA.caSigningTemplateARN | string | `""` | See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
+| upstreamAuthority.awsPCA.certificateAuthorityARN | string | `""` | ARN of the "upstream" CA certificate |
+| upstreamAuthority.awsPCA.enabled | bool | `false` |  |
+| upstreamAuthority.awsPCA.endpoint | string | `""` | See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
+| upstreamAuthority.awsPCA.region | string | `""` | AWS Region to use |
+| upstreamAuthority.awsPCA.signingAlgorithm | string | `""` | See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
+| upstreamAuthority.awsPCA.supplementalBundlePath | Optional | `""` | Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle. |
 | upstreamAuthority.certManager.ca.create | bool | `false` | Creates a Cert-Manager CA |
 | upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
 | upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -100,26 +100,26 @@ plugins:
   {{- end }}
   {{- end }}
 
-  {{- with .Values.upstreamAuthority.awspca }}
+  {{- with .Values.upstreamAuthority.awsPCA }}
   {{- if eq (.enabled | toString) "true" }}
   {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
   UpstreamAuthority:
     - aws_pca:
         plugin_data:
           region: {{ .region | quote }}
-          certificate_authority_arn: {{ .certificate_authority_arn | quote }}
-          ca_signing_template_arn: {{ .ca_signing_template_arn | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
-          {{- if ne .signing_algorithm "" }}
-          signing_algorithm: {{ .signing_algorithm | quote }}
+          certificate_authority_arn: {{ .certificateAuthorityArn | quote }}
+          ca_signing_template_arn: {{ .caSigningTemplateArn | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
+          {{- if ne .signingAlgorithm "" }}
+          signing_algorithm: {{ .signingAlgorithm | quote }}
           {{- end }}          
-          {{- if ne .assume_role_arn "" }}
-          assume_role_arn: {{ .assume_role_arn | quote }}
+          {{- if ne .assumeRoleArn "" }}
+          assume_role_arn: {{ .assumeRoleArn | quote }}
           {{- end }}          
           {{- if ne .endpoint "" }}
           endpoint: {{ .endpoint | quote }}
           {{- end }}          
-          {{- if ne .supplemental_bundle_path "" }}
-          supplemental_bundle_path: {{ .supplemental_bundle_path  | quote }}
+          {{- if ne .supplementalBundlePath "" }}
+          supplemental_bundle_path: {{ .supplementalBundlePath  | quote }}
           {{- end }}          
   {{- end }}
   {{- end }}  

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -99,6 +99,30 @@ plugins:
           workload_api_socket: "/run/spire/upstream_agent/spire-agent.sock"
   {{- end }}
   {{- end }}
+
+  {{- with .Values.upstreamAuthority.awspca }}
+  {{- if eq (.enabled | toString) "true" }}
+  {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
+  UpstreamAuthority:
+    - aws_pca:
+        plugin_data:
+          region: {{ .region | quote }}
+          certificate_authority_arn: {{ .certificate_authority_arn | quote }}
+          ca_signing_template_arn: {{ .ca_signing_template_arn | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
+          {{- if ne .signing_algorithm "" }}
+          signing_algorithm: {{ .signing_algorithm | quote }}
+          {{- end }}          
+          {{- if ne .assume_role_arn "" }}
+          assume_role_arn: {{ .assume_role_arn | quote }}
+          {{- end }}          
+          {{- if ne .endpoint "" }}
+          endpoint: {{ .endpoint | quote }}
+          {{- end }}          
+          {{- if ne .supplemental_bundle_path "" }}
+          supplemental_bundle_path: {{ .supplemental_bundle_path  | quote }}
+          {{- end }}          
+  {{- end }}
+  {{- end }}  
 {{- if gt $upstreamAuthorityUsed 1 }}
 {{- fail "You can only enable a single Upstream Authority." }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -107,13 +107,13 @@ plugins:
     - aws_pca:
         plugin_data:
           region: {{ .region | quote }}
-          certificate_authority_arn: {{ .certificateAuthorityArn | quote }}
-          ca_signing_template_arn: {{ .caSigningTemplateArn | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
+          certificate_authority_arn: {{ .certificateAuthorityARN | quote }}
+          ca_signing_template_arn: {{ .caSigningTemplateARN | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
           {{- if ne .signingAlgorithm "" }}
           signing_algorithm: {{ .signingAlgorithm | quote }}
           {{- end }}          
-          {{- if ne .assumeRoleArn "" }}
-          assume_role_arn: {{ .assumeRoleArn | quote }}
+          {{- if ne .assumeRoleARN "" }}
+          assume_role_arn: {{ .assumeRoleARN | quote }}
           {{- end }}          
           {{- if ne .endpoint "" }}
           endpoint: {{ .endpoint | quote }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -170,7 +170,7 @@ ca_subject:
   country: NL
   organization: Example
   common_name: example.org
-
+  
 upstreamAuthority:
   disk:
     enabled: false
@@ -184,6 +184,25 @@ upstreamAuthority:
         certificate: ""
         key: ""
         bundle: ""
+  awspca:
+    enabled: false
+    # -- AWS Region to use
+    region: ""
+    # -- ARN of the "upstream" CA certificate
+    certificate_authority_arn: ""
+    # -- (Optional) ARN of an IAM role to assume
+    assume_role_arn: ""
+    # -- (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only. 
+    # -- See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values.
+    ca_signing_template_arn: ""
+    # -- (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default. 
+    # -- See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values.
+    signing_algorithm: ""
+    # -- (Optional) Endpoint as hostname or fully-qualified URI that overrides the default endpoint. 
+    # -- See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information.
+    endpoint: ""
+    # -- (Optional) Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle.
+    supplemental_bundle_path: ""
   certManager:
     enabled: false
     rbac:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -170,6 +170,7 @@ ca_subject:
   country: NL
   organization: Example
   common_name: example.org
+  
 upstreamAuthority:
   disk:
     enabled: false
@@ -184,16 +185,16 @@ upstreamAuthority:
         key: ""
         bundle: ""
   awsPCA:
-    enabled: true
+    enabled: false
     # -- AWS Region to use
-    region: "us-west-2"
+    region: ""
     # -- ARN of the "upstream" CA certificate
-    certificateAuthorityArn: "arn:aws:acm-pca:us-west-2:945673678728:certificate-authority/636dbcd8-203f-43e0-9701-be854b094a2b"
+    certificateAuthorityARN: ""
     # -- (Optional) ARN of an IAM role to assume
-    assumeRoleArn: "arn:aws:iam::945673678728:role/PCAAccessSpireRole"
+    assumeRoleARN: ""
     # -- (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only. 
     # -- See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values.
-    caSigningTemplateArn: ""
+    caSigningTemplateARN: ""
     # -- (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default. 
     # -- See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values.
     signingAlgorithm: ""

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -170,7 +170,6 @@ ca_subject:
   country: NL
   organization: Example
   common_name: example.org
-  
 upstreamAuthority:
   disk:
     enabled: false
@@ -184,7 +183,7 @@ upstreamAuthority:
         certificate: ""
         key: ""
         bundle: ""
-  awspca:
+  awsPCA:
     enabled: false
     # -- AWS Region to use
     region: ""

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -174,7 +174,7 @@ ca_subject:
   country: NL
   organization: Example
   common_name: example.org
-  
+
 upstreamAuthority:
   disk:
     enabled: false

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -184,24 +184,24 @@ upstreamAuthority:
         key: ""
         bundle: ""
   awsPCA:
-    enabled: false
+    enabled: true
     # -- AWS Region to use
-    region: ""
+    region: "us-west-2"
     # -- ARN of the "upstream" CA certificate
-    certificate_authority_arn: ""
+    certificateAuthorityArn: "arn:aws:acm-pca:us-west-2:945673678728:certificate-authority/636dbcd8-203f-43e0-9701-be854b094a2b"
     # -- (Optional) ARN of an IAM role to assume
-    assume_role_arn: ""
+    assumeRoleArn: "arn:aws:iam::945673678728:role/PCAAccessSpireRole"
     # -- (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only. 
     # -- See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values.
-    ca_signing_template_arn: ""
+    caSigningTemplateArn: ""
     # -- (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default. 
     # -- See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values.
-    signing_algorithm: ""
+    signingAlgorithm: ""
     # -- (Optional) Endpoint as hostname or fully-qualified URI that overrides the default endpoint. 
     # -- See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information.
     endpoint: ""
     # -- (Optional) Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle.
-    supplemental_bundle_path: ""
+    supplementalBundlePath: ""
   certManager:
     enabled: false
     rbac:


### PR DESCRIPTION
This change allows aws_pca to be configured via values of this chart.

__Requires 1.7.1 version__ per [bug](https://github.com/spiffe/spire/issues/4351) - this will not work until 1.7.1 is released.