### PR TITLE
Allow job hooks to be disabled

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -89,6 +89,8 @@ Now you can interact with the Spire agent socket from your own application. The 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.deleteHooks.enabled | bool | `true` | Enable Helm hooks to autofix common delete issues (should be disabled when using `helm template`) |
+| global.installAndUpgradeHooks.enabled | bool | `true` | Enable Helm hooks to autofix common install/upgrade issues (should be disabled when using `helm template`) |
 | global.k8s.clusterDomain | string | `"cluster.local"` |  |
 | global.spire.bundleConfigMap | string | `""` | Override all instances of bundleConfigMap |
 | global.spire.clusterName | string | `"example-cluster"` |  |
@@ -162,6 +164,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-oidc-discovery-provider.config.additionalDomains | list | `["localhost"]` | Add additional domains that can be used for oidc discovery |
 | spiffe-oidc-discovery-provider.config.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | spiffe-oidc-discovery-provider.configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
+| spiffe-oidc-discovery-provider.deleteHook.enabled | bool | `true` | Enable Helm hooks to autofix common delete issues (should be disabled when using `helm template`) |
 | spiffe-oidc-discovery-provider.fullnameOverride | string | `""` |  |
 | spiffe-oidc-discovery-provider.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spiffe-oidc-discovery-provider.image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
@@ -220,7 +223,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-oidc-discovery-provider.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spiffe-oidc-discovery-provider.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| spiffe-oidc-discovery-provider.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with deleting |
 | spire-agent.bundleConfigMap | string | `"spire-bundle"` |  |
 | spire-agent.clusterName | string | `"example-cluster"` |  |
 | spire-agent.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Agent ConfigMap |
@@ -295,6 +297,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.clusterName | string | `"example-cluster"` |  |
 | spire-server.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Server ConfigMap |
 | spire-server.controllerManager.configMap.annotations | object | `{}` | Annotations to add to the Controller Manager ConfigMap |
+| spire-server.controllerManager.deleteHook.enabled | bool | `true` | Enable Helm hook to autofix common delete issues (should be disabled when using `helm template`) |
 | spire-server.controllerManager.enabled | bool | `false` |  |
 | spire-server.controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | spire-server.controllerManager.identities.enabled | bool | `true` |  |
@@ -310,12 +313,12 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | spire-server.controllerManager.image.tag | string | `"0.2.3"` | Overrides the image tag |
 | spire-server.controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
+| spire-server.controllerManager.installAndUpgradeHook.enabled | bool | `true` | Enable Helm hook to autofix common install/upgrade issues (should be disabled when using `helm template`) |
 | spire-server.controllerManager.resources | object | `{}` |  |
 | spire-server.controllerManager.securityContext | object | `{}` |  |
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
 | spire-server.controllerManager.service.port | int | `443` |  |
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
-| spire-server.controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -228,6 +228,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-oidc-discovery-provider.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spiffe-oidc-discovery-provider.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| spiffe-oidc-discovery-provider.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with deleting |
 | spire-agent.bundleConfigMap | string | `"spire-bundle"` |  |
 | spire-agent.clusterName | string | `"example-cluster"` |  |
 | spire-agent.configMap.annotations | object | `{}` | Annotations to add to the SPIRE Agent ConfigMap |
@@ -322,7 +323,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
 | spire-server.controllerManager.service.port | int | `443` |  |
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
-| spire-server.controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources. |
+| spire-server.controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -322,6 +322,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.service.annotations | object | `{}` |  |
 | spire-server.controllerManager.service.port | int | `443` |  |
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
+| spire-server.controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources. |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -103,5 +103,6 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
+| upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with deleting |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -45,6 +45,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | config.additionalDomains | list | `["localhost"]` | Add additional domains that can be used for oidc discovery |
 | config.logLevel | string | `"info"` | The log level, valid values are "debug", "info", "warn", and "error" |
 | configMap.annotations | object | `{}` | Annotations to add to the SPIFFE OIDC Discovery Provider ConfigMap |
+| deleteHook.enabled | bool | `true` | Enable Helm hooks to autofix common delete issues (should be disabled when using `helm template`) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
@@ -103,6 +104,5 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with deleting |
 
 ----------------------------------------------

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.upgradeHooks.enabled | toString) "true" }}
+{{- if eq ((dig "deleteHooks" "enabled" .Values.deleteHook.enabled .Values.global) | toString) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.upgradeHooks.enabled | toString) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -71,3 +72,4 @@ spec:
           - deployment
           - {{ include "spiffe-oidc-discovery-provider.fullname" . }}
           - --wait
+{{- end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -136,7 +136,7 @@ serviceAccount:
   name: ""
 
 helmHooks:
-  # -- Enable jobs to run at upgrade time to work around issues with deleting
+  # -- Enable Helm hooks to  autofix common issues (should be disabled when using `helm template`)
   enabled: true
 
 autoscaling:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -135,6 +135,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+upgradeHooks:
+  # -- Enable jobs to run at upgrade time to work around issues with deleting
+  enabled: true
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -135,7 +135,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-upgradeHooks:
+helmHooks:
   # -- Enable jobs to run at upgrade time to work around issues with deleting
   enabled: true
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -135,8 +135,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-helmHooks:
-  # -- Enable Helm hooks to  autofix common issues (should be disabled when using `helm template`)
+deleteHook:
+  # -- Enable Helm hooks to autofix common delete issues (should be disabled when using `helm template`)
   enabled: true
 
 autoscaling:

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -100,6 +100,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | clusterName | string | `"example-cluster"` |  |
 | configMap.annotations | object | `{}` | Annotations to add to the SPIRE Server ConfigMap |
 | controllerManager.configMap.annotations | object | `{}` | Annotations to add to the Controller Manager ConfigMap |
+| controllerManager.deleteHook.enabled | bool | `true` | Enable Helm hook to autofix common delete issues (should be disabled when using `helm template`) |
 | controllerManager.enabled | bool | `false` |  |
 | controllerManager.identities.dnsNameTemplates | list | `[]` |  |
 | controllerManager.identities.enabled | bool | `true` |  |
@@ -115,12 +116,12 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | controllerManager.image.repository | string | `"spiffe/spire-controller-manager"` | The repository within the registry |
 | controllerManager.image.tag | string | `"0.2.3"` | Overrides the image tag |
 | controllerManager.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
+| controllerManager.installAndUpgradeHook.enabled | bool | `true` | Enable Helm hook to autofix common install/upgrade issues (should be disabled when using `helm template`) |
 | controllerManager.resources | object | `{}` |  |
 | controllerManager.securityContext | object | `{}` |  |
 | controllerManager.service.annotations | object | `{}` |  |
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
-| controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -120,7 +120,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | controllerManager.service.annotations | object | `{}` |  |
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
-| controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources. |
+| controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -120,6 +120,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | controllerManager.service.annotations | object | `{}` |  |
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
+| controllerManager.upgradeHooks.enabled | bool | `true` | Enable jobs to run at upgrade time to work around issues with custom resources. |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |

--- a/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
@@ -10,7 +10,7 @@ webhooks:
         name: {{ include "spire-controller-manager.fullname" . }}-webhook
         namespace: {{ include "spire-server.namespace" . }}
         path: /validate-spire-spiffe-io-v1alpha1-clusterfederatedtrustdomain
-    {{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
+    {{- if eq (.Values.controllerManager.installAndUpgradeHook.enabled | toString) "true" }}
     failurePolicy: Ignore # Actual value to be set by post install/upgrade hooks
     {{- else }}
     failurePolicy: {{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}

--- a/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-webhook.yaml
@@ -10,7 +10,11 @@ webhooks:
         name: {{ include "spire-controller-manager.fullname" . }}-webhook
         namespace: {{ include "spire-server.namespace" . }}
         path: /validate-spire-spiffe-io-v1alpha1-clusterfederatedtrustdomain
+    {{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
     failurePolicy: Ignore # Actual value to be set by post install/upgrade hooks
+    {{- else }}
+    failurePolicy: {{ .Values.controllerManager.validatingWebhookConfiguration.failurePolicy }}
+    {{- end }}
     name: vclusterfederatedtrustdomain.kb.io
     rules:
       - apiGroups: ["spire.spiffe.io"]

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
+{{- if eq ((dig "installAndUpgradeHooks" "enabled" .Values.controllerManager.installAndUpgradeHook.enabled .Values.global) | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
@@ -83,5 +84,6 @@ spec:
                 }
               ]
             }
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
+{{- if eq ((dig "installAndUpgradeHooks" "enabled" .Values.controllerManager.installAndUpgradeHook.enabled .Values.global) | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
@@ -83,5 +84,6 @@ spec:
                 }
               ]
             }
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-delete-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-delete-hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq ((dig "deleteHooks" "enabled" .Values.controllerManager.deleteHook.enabled .Values.global) | toString) "true" }}
 {{- if .Values.upstreamAuthority.spire.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -87,4 +88,5 @@ spec:
           - app.kubernetes.io/instance={{ include "spire-server.name" . }},app.kubernetes.io/name={{ .Release.Name }},app.kubernetes.io/component=server
           - -n
           - {{ include "spire-server.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
+{{- if eq ((dig "installAndUpgradeHooks" "enabled" .Values.controllerManager.installAndUpgradeHook.enabled .Values.global) | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.controllerManager.upgradeHooks.enabled | toString) "true" }}
 {{- if eq (.Values.controllerManager.enabled | toString) "true" }}
 {{- if eq .Values.controllerManager.validatingWebhookConfiguration.failurePolicy "Fail" }}
 apiVersion: v1
@@ -83,5 +84,6 @@ spec:
                 }
               ]
             }
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -244,7 +244,7 @@ notifier:
 controllerManager:
   enabled: false
   upgradeHooks:
-    # -- Enable jobs to run at upgrade time to work around issues with custom resources.
+    # -- Enable jobs to run at upgrade time to work around issues with custom resources
     enabled: true
 
   image:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -243,6 +243,9 @@ notifier:
 
 controllerManager:
   enabled: false
+  upgradeHooks:
+    # -- Enable jobs to run at upgrade time to work around issues with custom resources.
+    enabled: true
 
   image:
     # -- The OCI registry to pull the image from

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -243,7 +243,7 @@ notifier:
 
 controllerManager:
   enabled: false
-  upgradeHooks:
+  helmHooks:
     # -- Enable jobs to run at upgrade time to work around issues with custom resources
     enabled: true
 

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -244,7 +244,7 @@ notifier:
 controllerManager:
   enabled: false
   helmHooks:
-    # -- Enable jobs to run at upgrade time to work around issues with custom resources
+    # -- Enable Helm hooks to  autofix common issues (should be disabled when using `helm template`)
     enabled: true
 
   image:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -250,8 +250,11 @@ notifier:
 
 controllerManager:
   enabled: false
-  helmHooks:
-    # -- Enable Helm hooks to  autofix common issues (should be disabled when using `helm template`)
+  installAndUpgradeHook:
+    # -- Enable Helm hook to autofix common install/upgrade issues (should be disabled when using `helm template`)
+    enabled: true
+  deleteHook:
+    # -- Enable Helm hook to autofix common delete issues (should be disabled when using `helm template`)
     enabled: true
 
   image:

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -20,6 +20,13 @@ global:
       # -- Override all Spire image registries at once
       registry: ""
 
+  installAndUpgradeHooks:
+    # -- Enable Helm hooks to autofix common install/upgrade issues (should be disabled when using `helm template`)
+    enabled: true
+  deleteHooks:
+    # -- Enable Helm hooks to autofix common delete issues (should be disabled when using `helm template`)
+    enabled: true
+
 #  telemetry:
 #    prometheus:
 #      enabled: true


### PR DESCRIPTION
Github wouldn't let me reopen #203 so creating a new pr. Here is the description from the original PR.

This eliminates a bunch of code for folks that don't need the hooks:

```
$ helm template charts/spire/ | wc -l
1150
$ helm template charts/spire/ --set spire-server.controllerManager.upgradeHooks.enabled=false | wc -l
868
```
It also runs faster in some environments.