### PR TITLE
Change Tornjak backend default port

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -414,7 +414,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.tornjak.resources | object | `{}` |  |
 | spire-server.tornjak.service.annotations | object | `{}` |  |
-| spire-server.tornjak.service.ports | object | `{"http":10080,"https":10443}` | Ports for tornjak |
+| spire-server.tornjak.service.ports | object | `{"http":10000,"https":10443}` | Ports for tornjak |
 | spire-server.tornjak.service.type | string | `"ClusterIP"` |  |
 | spire-server.tornjak.startupProbe.failureThreshold | int | `3` |  |
 | spire-server.tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -212,7 +212,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tornjak.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | tornjak.resources | object | `{}` |  |
 | tornjak.service.annotations | object | `{}` |  |
-| tornjak.service.ports | object | `{"http":10080,"https":10443}` | Ports for tornjak |
+| tornjak.service.ports | object | `{"http":10000,"https":10443}` | Ports for tornjak |
 | tornjak.service.type | string | `"ClusterIP"` |  |
 | tornjak.startupProbe.failureThreshold | int | `3` |  |
 | tornjak.startupProbe.initialDelaySeconds | int | `5` | Initial delay seconds for |

--- a/charts/spire/charts/spire-server/templates/NOTES.txt
+++ b/charts/spire/charts/spire-server/templates/NOTES.txt
@@ -15,7 +15,7 @@ Tornjak runs without authentication and is therefore NOT suitable to run in prod
 Only use in test environments!
 
 Access Tornjak:
-   kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.service.ports.http }}:10080
+   kubectl -n {{ include "spire-server.namespace" . }} port-forward service/{{ include "spire-tornjak.servicename" . }} {{ .Values.tornjak.service.ports.http }}:10000
 {{- if eq (include "spire-tornjak.connectionType" .) "http" }}
   Open browser to: http://localhost:{{ .Values.tornjak.service.ports.http }}
 {{- else if eq (include "spire-tornjak.connectionType" .) "tls" }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -183,7 +183,7 @@ spec:
             httpGet:
               scheme: HTTP
               path: /api/tornjak/serverinfo
-              port: 10080
+              port: 10000
             {{- toYaml .Values.tornjak.startupProbe | nindent 12 }}
           {{- end }}
           args:
@@ -193,7 +193,7 @@ spec:
             - /run/spire/tornjak-config/server.conf
           ports:
             - name: tornjak-http
-              containerPort: 10080
+              containerPort: 10000
               protocol: TCP
             - name: tornjak-https
               containerPort: 10443

--- a/charts/spire/charts/spire-server/templates/tornjak-config.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-config.yaml
@@ -11,7 +11,7 @@ data:
       {{- if eq (include "spire-tornjak.connectionType" .) "http" }}
       http {
         enabled = true # if true, opens HTTP server
-        port = "10080" # if HTTP enabled, opens HTTP listen port at specified container port
+        port = "10000" # if HTTP enabled, opens HTTP listen port at specified container port
       }
       {{- end }}
       {{- if eq (include "spire-tornjak.connectionType" .) "tls" }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -196,13 +196,13 @@ upstreamAuthority:
     certificateAuthorityARN: ""
     # -- (Optional) ARN of an IAM role to assume
     assumeRoleARN: ""
-    # -- (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only. 
+    # -- (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only.
     # -- See Using Templates (https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values.
     caSigningTemplateARN: ""
-    # -- (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default. 
+    # -- (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default.
     # -- See Issue Certificate (https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values.
     signingAlgorithm: ""
-    # -- (Optional) Endpoint as hostname or fully-qualified URI that overrides the default endpoint. 
+    # -- (Optional) Endpoint as hostname or fully-qualified URI that overrides the default endpoint.
     # -- See AWS SDK Config docs (https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information.
     endpoint: ""
     # -- (Optional) Path to a file containing PEM-encoded CA certificates that should be additionally included in the bundle.
@@ -387,7 +387,7 @@ tornjak:
     type: ClusterIP
     # -- Ports for tornjak
     ports:
-      http: 10080
+      http: 10000
       https: 10443
     annotations: {}
 

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -34,7 +34,7 @@ This chart requires access to Tornjak Backend (`tornjakFrontend.apiServerURL`).
 This URL needs to be reachable from your web browser and can therefore not be a cluster internal URL.
 
 Obtain the URL for Tornjak APIs. If deployed in the same cluster, locally,
-Tornjak APIs are typically available at `http://localhost:10080`.
+Tornjak APIs are typically available at `http://localhost:10000`.
 Review Tornjak documentation for more details.
 
 ## Usage

--- a/charts/spire/charts/tornjak-frontend/README.md.gotmpl
+++ b/charts/spire/charts/tornjak-frontend/README.md.gotmpl
@@ -36,7 +36,7 @@ This chart requires access to Tornjak Backend (`tornjakFrontend.apiServerURL`).
 This URL needs to be reachable from your web browser and can therefore not be a cluster internal URL.
 
 Obtain the URL for Tornjak APIs. If deployed in the same cluster, locally,
-Tornjak APIs are typically available at `http://localhost:10080`.
+Tornjak APIs are typically available at `http://localhost:10000`.
 Review Tornjak documentation for more details.
 
 ## Usage


### PR DESCRIPTION
Due to NAT Slipstream 2.0 attack, some browser do not connect on port 10080. 
Change the default port for Tornjak backend from 10080 to 10000. 

https://chromestatus.com/feature/6510270304223232