### PR TITLE
fix some issues found with kube-score

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -358,6 +358,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | spire-server.ingress.tls | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
+| spire-server.jobAnnotations | object | `{}` |  |
 | spire-server.jwtIssuer | string | `"https://oidc-discovery.example.org"` | The JWT issuer domain |
 | spire-server.keyManager.awsKMS.accessKeyID | Optional | `""` | Access key ID for the AWS account. It's recommended to use an IAM role instead. See [here](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) to learn how to annotate your SPIRE Server Service Account to assume an IAM role. |
 | spire-server.keyManager.awsKMS.enabled | bool | `false` |  |
@@ -405,6 +406,7 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | spire-server.tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | spire-server.tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| spire-server.tools.kubectl.image.securityContext | object | `{}` |  |
 | spire-server.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -161,6 +161,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| jobAnnotations | object | `{}` |  |
 | jwtIssuer | string | `"https://oidc-discovery.example.org"` | The JWT issuer domain |
 | keyManager.awsKMS.accessKeyID | Optional | `""` | Access key ID for the AWS account. It's recommended to use an IAM role instead. See [here](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) to learn how to annotate your SPIRE Server Service Account to assume an IAM role. |
 | keyManager.awsKMS.enabled | bool | `false` |  |
@@ -208,6 +209,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
 | tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| tools.kubectl.image.securityContext | object | `{}` |  |
 | tools.kubectl.image.tag | string | `""` | Overrides the image tag |
 | tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -51,6 +51,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+    {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/templates/service.yaml
+++ b/charts/spire/charts/spire-server/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- include "spire-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  clusterIP: None
   ports:
     - name: grpc
       port: {{ .Values.service.port }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -51,8 +51,10 @@ spec:
       initContainers:
       {{- if and .Values.upstreamAuthority.certManager.enabled .Values.upstreamAuthority.certManager.ca.create }}
         - name: wait
+          {{- with .Values.tools.kubectl.image.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ template "spire-lib.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
           args:
             - wait
@@ -63,6 +65,10 @@ spec:
             - issuer
             - {{ include "spire-server.fullname" $ }}-ca
           imagePullPolicy: {{ .Values.tools.kubectl.image.pullPolicy }}
+          {{- with .Values.tools.kubectl.image.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if gt (len .Values.initContainers) 0 }}
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -34,6 +34,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+jobAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -348,6 +350,15 @@ tools:
       version: ""
       # -- Overrides the image tag
       tag: ""
+
+      securityContext: {}
+        # readOnlyRootFilesystem: true
+        # privileged: true
+        # runAsNonRoot: true
+        # runAsUser: 1000
+        # capabilities:
+        #   drop:
+        #   - ALL
 
 telemetry:
   prometheus:


### PR DESCRIPTION
Statefulsets are supposed to have headless services assigned to them, see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations https://kubernetes.io/docs/concepts/services-networking/service/#headless-services

The others changes are probably easier to see why kube-score complains