### PR TITLE
support overriding annotations in jobs

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -191,6 +191,8 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.tag | string | `"1.24.0-alpine"` | Overrides the image tag |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spiffe-oidc-discovery-provider.insecureScheme.nginx.resources | object | `{}` |  |
+| spiffe-oidc-discovery-provider.jobAnnotations."helm.sh/hook" | string | `"pre-delete"` |  |
+| spiffe-oidc-discovery-provider.jobAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
 | spiffe-oidc-discovery-provider.jwtIssuer | string | `"https://oidc-discovery.example.org"` |  |
 | spiffe-oidc-discovery-provider.livenessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for livenessProbe |
 | spiffe-oidc-discovery-provider.livenessProbe.periodSeconds | int | `5` | Period seconds for livenessProbe |
@@ -361,6 +363,12 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | spire-server.ingress.tls | list | `[]` |  |
 | spire-server.initContainers | list | `[]` |  |
+| spire-server.jobPostInstallAnnotations."helm.sh/hook" | string | `"post-install"` |  |
+| spire-server.jobPostInstallAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
+| spire-server.jobPostUpgradeAnnotations."helm.sh/hook" | string | `"post-upgrade"` |  |
+| spire-server.jobPostUpgradeAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
+| spire-server.jobPreUpgradeAnnotations."helm.sh/hook" | string | `"pre-upgrade"` |  |
+| spire-server.jobPreUpgradeAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
 | spire-server.jwtIssuer | string | `"https://oidc-discovery.example.org"` | The JWT issuer domain |
 | spire-server.keyManager.disk.enabled | bool | `true` |  |
 | spire-server.keyManager.memory.enabled | bool | `false` |  |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -66,6 +66,8 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 | insecureScheme.nginx.image.tag | string | `"1.24.0-alpine"` | Overrides the image tag |
 | insecureScheme.nginx.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | insecureScheme.nginx.resources | object | `{}` |  |
+| jobAnnotations."helm.sh/hook" | string | `"pre-delete"` |  |
+| jobAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
 | jwtIssuer | string | `"https://oidc-discovery.example.org"` |  |
 | livenessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for livenessProbe |
 | livenessProbe.periodSeconds | int | `5` | Period seconds for livenessProbe |

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/pre-delete-hook.yaml
@@ -48,8 +48,9 @@ metadata:
   labels:
     {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+  {{- range $k, $v := .Values.jobAnnotations }}
+    {{ $k | quote }}: {{ $v }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -15,6 +15,11 @@ namespaceOverride: ""
 # -- Annotations for the deployment
 annotations: {}
 
+jobAnnotations:
+  "helm.sh/hook": pre-delete
+  "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+
+
 image:
   # -- The OCI registry to pull the image from
   registry: ghcr.io

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -159,6 +159,12 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| jobPostInstallAnnotations."helm.sh/hook" | string | `"post-install"` |  |
+| jobPostInstallAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
+| jobPostUpgradeAnnotations."helm.sh/hook" | string | `"post-upgrade"` |  |
+| jobPostUpgradeAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
+| jobPreUpgradeAnnotations."helm.sh/hook" | string | `"pre-upgrade"` |  |
+| jobPreUpgradeAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation, hook-succeeded, hook-failed"` |  |
 | jwtIssuer | string | `"https://oidc-discovery.example.org"` | The JWT issuer domain |
 | keyManager.disk.enabled | bool | `true` |  |
 | keyManager.memory.enabled | bool | `false` |  |

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -48,8 +48,9 @@ metadata:
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+  {{- range $k, $v := .Values.jobPostInstallAnnotations }}
+    {{ $k | quote }}: {{ $v }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -48,8 +48,9 @@ metadata:
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+  {{- range $k, $v := .Values.jobPostUpgradeAnnotations }}
+    {{ $k | quote }}: {{ $v }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -48,8 +48,9 @@ metadata:
   labels:
     {{- include "spire-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+  {{- range $k, $v := .Values.jobPreUpgradeAnnotations }}
+    {{ $k | quote }}: {{ $v }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -34,6 +34,18 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+jobPostInstallAnnotations:
+  "helm.sh/hook": post-install
+  "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+
+jobPreUpgradeAnnotations:
+  "helm.sh/hook": pre-upgrade
+  "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+
+jobPostUpgradeAnnotations:
+  "helm.sh/hook": post-upgrade
+  "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Should be a no-op 
```
helm template charts/spire -f .../src/github.com/spiffe/helm-charts/examples/production/values.yaml --debug | less > before
helm template charts/spire -f .../src/github.com/spiffe/helm-charts/examples/production/values.yaml --debug | less > after
```

```
% diff before after                                           
% echo $?     
0
```