### PR TITLE
Bump spire Helm Chart version from 0.11.1 to 0.12.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.11.1
+version: 0.12.0
 appVersion: "1.7.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* 5e2e8a91 Adds AWS KMS KeyManager support (#435)
* 77fe43f3 Cron job to check for and update images (#249)
* b7e15255 Allow job hooks to be disabled (#434)
* 5e4cf6f5 Clarify project issues identified with nesting document (#450)
* 72893515 Update spire bits to 1.7.2 (#452)
* dc8a4545 Array spacing in values is incorrect in a file. (#451)
* 94326d9c Fixup Helm docs
* ae8941c4 Support Nested Spire with External Agent (#117)
* f40743d4 Improve Tornjak documentation (#439)
* 0124f633 Bypass example-test for docs only changes (#449)
* 48a28980 Fix chainguard image references as per issue 442 (#443)
* bd393e95 Bump test chart dependencies (#445)
* a52818a7 Add a FAQ and switch rare issue from README to it (#437)
* e60f5287 option to set KeyManager memory in spire server (#444)
* a167ce68 Bump actions/setup-go from 4.0.1 to 4.1.0
* e774584c Bump test chart dependencies (#426)
* bfec27ef Fix jwtIssuer to allow for Uris including scheme (#425)
* 7a6e4f8d Change Tornjak backend default port (#436)
* 1e3039cc Bump spire Helm Chart version from 0.11.0 to 0.11.1 (#419)
* d2e16062 issuer naming should respect issuer_name override (#378)
* a2e5c36c Bump test chart dependencies (#416)
* a09e054d support annotations so oidc can be annotated (#391)
* 7d94b105 Update spire to 1.7.1 (#412)
* 9f4d4ace Add aws_pca to the spire-server (#404)
* af13f1fc Bump test chart dependencies (#401)
* 9a6768bc Add support for disabling container selectors (#399)
* 4687e20d Merge pull request #315 from spiffe/persistence-type
* e16210c6 Merge branch 'main' into persistence-type
* 624ca9cc Remove misadded lockfile (#400)
* 7ce67c62 Bump actions/checkout from 3.5.2 to 3.5.3 (#395)
* b85ba64d Bump helm/kind-action from 1.7.0 to 1.8.0 (#396)
* a6bdb4d1 Add persistence type flag
