### PR TITLE
Fix annotation for spire-oidc deployment

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ include "spiffe-oidc-discovery-provider.namespace" . }}
   labels:
     {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
   annotations:
-    {{- with .Values.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
This prevents and empty annotations block to be rendered when installing
the chart without annotations for spire-oidc-discovery-provider.
