### PR TITLE
Use deploy key in actions that create PRs

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.0.0
+        with:
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -64,7 +64,6 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v5.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           title: Bump test chart dependencies
           branch: bump-test-chart-deps
           commit-message: Bump test chart dependencies


### PR DESCRIPTION
Following steps in this [medium article](https://medium.com/prompt/trigger-another-github-workflow-without-using-a-personal-access-token-f594c21373ef) to hopefully fix issue where tests don't run for auto created PRs. Alternative approach is to create a bot account and use a PAT from that. 

fixes #334 (hopefully)