### PR TITLE
fix(charts/spire/spire-agent): podmonitor templating

### DIFF
--- a/charts/spire/charts/spire-agent/templates/podmonitor.yaml
+++ b/charts/spire/charts/spire-agent/templates/podmonitor.yaml
@@ -1,13 +1,13 @@
 {{- if (dig "telemetry" "prometheus" "podMonitor" "enabled" .Values.telemetry.prometheus.podMonitor.enabled .Values.global) }}
-{{- $namespace := include "spiffe-oidc-discovery-provider.podMonitor.namespace" . }}
-{{- $podNamespace := ( include "spiffe-oidc-discovery-provider.namespace" . ) }}
+{{- $namespace := include "spire-agent.podMonitor.namespace" . }}
+{{- $podNamespace := ( include "spire-agent.namespace" . ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "spiffe-oidc-discovery-provider.fullname" . }}
+  name: {{ include "spire-agent.fullname" . }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "spiffe-oidc-discovery-provider.labels" . | nindent 4 }}
+    {{- include "spire-agent.labels" . | nindent 4 }}
     {{- if ne (len (dig "telemetry" "prometheus" "podMonitor" "labels" (dict) .Values.global)) 0 }}
     {{- .Values.global.telemetry.prometheus.podMonitor.labels | toYaml | nindent 4 }}
     {{- end }}
@@ -17,7 +17,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "spiffe-oidc-discovery-provider.selectorLabels" . | nindent 6 }}
+      {{- include "spire-agent.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     - port: prom
   {{- if ne $namespace $podNamespace }}


### PR DESCRIPTION
This fixes a template error inside the helm chart where the `spire-agent` wants to use the `spiffe-oidc-discovery-provider` helm values. 