### PR TITLE
Allow configuration of priorityClassName on spire-server statefulset

### DIFF
--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -81,7 +81,7 @@ curl  --cacert CA/rootCA.crt --key client.key --cert client.crt https://localhos
 
 In order to run Tornjak with simple HTTP Connection only, make sure you don't create any `Secrets` or `ConfigMaps` listed above.
 
-## Parameters 
+## Parameters
 
 ### Chart parameters
 
@@ -103,6 +103,7 @@ In order to run Tornjak with simple HTTP Connection only, make sure you don't cr
 | `podAnnotations`                                                 | Annotations to add to pods                                                                                                                                                                                                                                         | `{}`                                                                                           |
 | `podSecurityContext`                                             | Pod security context                                                                                                                                                                                                                                               | `{}`                                                                                           |
 | `securityContext`                                                | Security context                                                                                                                                                                                                                                                   | `{}`                                                                                           |
+| `priorityClassName`                                              | Priority class assigned to statefulset pods                                                                                                                                                                                                                        | `""`                                                                                           |
 | `service.type`                                                   | Type of the Spire server service created                                                                                                                                                                                                                           | `ClusterIP`                                                                                    |
 | `service.port`                                                   | Port for the created service                                                                                                                                                                                                                                       | `8081`                                                                                         |
 | `service.annotations`                                            | Annotations to add to the service object                                                                                                                                                                                                                           | `{}`                                                                                           |

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -49,6 +49,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if or (gt (len .Values.initContainers) 0) (and .Values.upstreamAuthority.certManager.enabled .Values.upstreamAuthority.certManager.ca.create) }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       initContainers:
       {{- if and .Values.upstreamAuthority.certManager.enabled .Values.upstreamAuthority.certManager.ca.create }}
         - name: wait

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -25,13 +25,13 @@ image:
 ## @param imagePullSecrets [array] Pull secrets for images
 imagePullSecrets: []
 
-## @param nameOverride Name override 
+## @param nameOverride Name override
 nameOverride: ""
 
-## @param namespaceOverride Namespace override 
+## @param namespaceOverride Namespace override
 namespaceOverride: ""
 
-## @param fullnameOverride Fullname override 
+## @param fullnameOverride Fullname override
 fullnameOverride: ""
 
 ## @param serviceAccount.create Specifies whether a service account should be created
@@ -58,6 +58,9 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+## @param priorityClassName Priority class assigned to statefulset pods
+priorityClassName: ""
 
 ## @param service.type Type of the Spire server service created
 ## @param service.port Port for the created service

--- a/examples/production/values.yaml
+++ b/examples/production/values.yaml
@@ -23,6 +23,7 @@ spire-server:
       drop: [ALL]
     seccompProfile:
       type: RuntimeDefault
+  priorityClassName: system-cluster-critical
 
   logLevel: info
 


### PR DESCRIPTION
In #58 it was made possible to configure the `priorityClassName` for `Daemonsets`. With this PR it's now possible to the same for the `Statefulset` that is deployed as part of `spire-server`.