### PR TITLE
Bump spire Helm Chart version from 0.12.0 to 0.13.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: "1.7.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,8 +1,6 @@
 # spire
 
-<!-- This README.md is generated. Please edit README.md.gotmpl -->
-
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
@@ -84,6 +82,8 @@ Now you can interact with the Spire agent socket from your own application. The 
 | file://./charts/spire-agent | upstream-spire-agent(spire-agent) | 0.1.0 |
 | file://./charts/spire-server | spire-server | 0.1.0 |
 | file://./charts/tornjak-frontend | tornjak-frontend | 0.1.0 |
+
+<!-- The parameters section is generated using helm-docs.sh and should not be edited by hand. -->
 
 ## Parameters
 

--- a/release-chart.sh
+++ b/release-chart.sh
@@ -107,7 +107,7 @@ git pull
 git checkout --track -B "${branch_name}" main
 commits_since_previous_release="$(git log "${chart}-${current_version}..HEAD" --pretty=format:'* %h %s')"
 "${SED}" -i "s/version: ${current_version}/version: ${new_version}/" "charts/${chart}/Chart.yaml"
-./helm-docs.sh
+"${SED}" -i "s/${current_version}/${new_version}/" "charts/${chart}/README.md"
 git add "charts/${chart}/"{Chart.yaml,README.md}
 git commit -m "Bump ${chart} Helm Chart version from ${current_version} to ${new_version}" \
   -m "${commits_since_previous_release}" \


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* 38f0af44 Add support for Vault UpstreamAuthority plugin - K8s Auth (#415)
* 1aac2d48 Bump docker/login-action from 2 to 3
* 1f908676 Allow configuration of priorityClassName on spire-server statefulset (#480)
* 9ad2ed59 option to configure agent sds (#479)
* 693ce084 Remove ## values section from chart readms
* 65d56957 Migrate to readme-generator for helm maintained by bitnami (#431)
* dcc60a28 fix(charts/spire/spire-agent): podmonitor templating (#478)
* 48adb886 Bump actions/checkout from 3.6.0 to 4.0.0
* d1f52d69 Bump sigstore/cosign-installer from 3.1.1 to 3.1.2 (#473)
* 5273f4e5 Switch mysql and postgresql tests to HA Production configs (#471)
* e81a59a7 ingress-nginx production tests and spiffe-oidc-discovery-provider example (#136)
* b05175e2 Bump actions/checkout from 3.5.3 to 3.6.0
* 51cba5b5 Add customPlugins and unsupportedBuiltInPlugins sections to spire-server (#198)
* f4ee2c2b Bump github.com/onsi/ginkgo/v2 from 2.11.0 to 2.12.0 in /tests (#468)
* c817dd24 support datastore password secret created by external resources (#464)
* 71ac5afa Split steps in check-versions wf for easier debugging (#467)
* d91403af Scan for updates to new images (#466)
* 7a5456e4 Bump helm.sh/helm/v3 from 3.11.3 to 3.12.3 in /tests (#462)
* cbe00011 Federation test (#423)
