### PR TITLE
Fix spire-server configmap UpstreamAuthority/aws_pca and KeyManager/a…

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -89,19 +89,19 @@ plugins:
   {{- if eq (.enabled | toString) "true" }}
   {{- $keyManagerUsed = add1 $keyManagerUsed }}
   KeyManager:
-    - aws_kms:
-        plugin_data:
-          region: {{ .region | quote }}
-          key_metadata_file: "/run/spire/data/aws-kms-key-metadata"
-          {{- if ne .accessKeyID "" }}
-          access_key_id: "${AWS_KMS_ACCESS_KEY_ID}"
-          {{- end }}
-          {{- if ne .secretAccessKey "" }}
-          secret_access_key: "${AWS_KMS_SECRET_ACCESS_KEY}"
-          {{- end }}
-          {{- if or (ne .keyPolicy.policy "") (ne .keyPolicy.existingConfigMap "") }}
-          key_policy_file: "/run/spire/data/aws-kms-key-policy.json"
-          {{- end }}
+    aws_kms:
+      plugin_data:
+        region: {{ .region | quote }}
+        key_metadata_file: "/run/spire/data/aws-kms-key-metadata"
+        {{- if ne .accessKeyID "" }}
+        access_key_id: "${AWS_KMS_ACCESS_KEY_ID}"
+        {{- end }}
+        {{- if ne .secretAccessKey "" }}
+        secret_access_key: "${AWS_KMS_SECRET_ACCESS_KEY}"
+        {{- end }}
+        {{- if or (ne .keyPolicy.policy "") (ne .keyPolicy.existingConfigMap "") }}
+        key_policy_file: "/run/spire/data/aws-kms-key-policy.json"
+        {{- end }}
   {{- end }}
   {{- end }}
 
@@ -193,23 +193,23 @@ plugins:
   {{- if eq (.enabled | toString) "true" }}
   {{- $upstreamAuthorityUsed = add1 $upstreamAuthorityUsed }}
   UpstreamAuthority:
-    - aws_pca:
-        plugin_data:
-          region: {{ .region | quote }}
-          certificate_authority_arn: {{ .certificateAuthorityARN | quote }}
-          ca_signing_template_arn: {{ .caSigningTemplateARN | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
-          {{- if ne .signingAlgorithm "" }}
-          signing_algorithm: {{ .signingAlgorithm | quote }}
-          {{- end }}          
-          {{- if ne .assumeRoleARN "" }}
-          assume_role_arn: {{ .assumeRoleARN | quote }}
-          {{- end }}          
-          {{- if ne .endpoint "" }}
-          endpoint: {{ .endpoint | quote }}
-          {{- end }}          
-          {{- if ne .supplementalBundlePath "" }}
-          supplemental_bundle_path: {{ .supplementalBundlePath  | quote }}
-          {{- end }}          
+    aws_pca:
+      plugin_data:
+        region: {{ .region | quote }}
+        certificate_authority_arn: {{ .certificateAuthorityARN | quote }}
+        ca_signing_template_arn: {{ .caSigningTemplateARN | default "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1" | quote }}
+        {{- if ne .signingAlgorithm "" }}
+        signing_algorithm: {{ .signingAlgorithm | quote }}
+        {{- end }}          
+        {{- if ne .assumeRoleARN "" }}
+        assume_role_arn: {{ .assumeRoleARN | quote }}
+        {{- end }}          
+        {{- if ne .endpoint "" }}
+        endpoint: {{ .endpoint | quote }}
+        {{- end }}          
+        {{- if ne .supplementalBundlePath "" }}
+        supplemental_bundle_path: {{ .supplementalBundlePath  | quote }}
+        {{- end }}          
   {{- end }}
   {{- end }}  
 {{- if gt $upstreamAuthorityUsed 1 }}

--- a/tests/unit/spire_test.go
+++ b/tests/unit/spire_test.go
@@ -103,6 +103,5 @@ spire-server:
 			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
 			Expect(notes).Should(ContainSubstring("\"aws_pca\": {"))
         })
-
 	})
 })

--- a/tests/unit/spire_test.go
+++ b/tests/unit/spire_test.go
@@ -71,4 +71,38 @@ spire-server:
 			Expect(notes).Should(ContainSubstring("join_token"))
 		})
 	})
+	Describe("spire-server.keyManager.aws_kms", func() {
+		It("plugin set ok", func() {
+			objs, err := ValueStringRender(chart, `
+spire-server:
+  keyManager:
+    awsKMS:
+      enabled: true
+      region: us-west-2
+      plugin_data: {}
+    disk:
+      enabled: false
+`)
+			Expect(err).Should(Succeed())
+			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
+			Expect(notes).Should(ContainSubstring("\"aws_kms\": {"))
+        })
+
+	})
+	Describe("spire-server.UpstreamAuthority.aws_pca", func() {
+		It("plugin set ok", func() {
+			objs, err := ValueStringRender(chart, `
+spire-server:
+  upstreamAuthority:
+    awsPCA:
+      enabled: true
+      region: us-west-2
+      plugin_data: {}
+`)
+			Expect(err).Should(Succeed())
+			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
+			Expect(notes).Should(ContainSubstring("\"aws_pca\": {"))
+        })
+
+	})
 })

--- a/tests/unit/spire_test.go
+++ b/tests/unit/spire_test.go
@@ -16,7 +16,7 @@ func ValueStringRender(chart *helmchart.Chart, values string) (map[string]string
 		return nil, err
 	}
 	ro := helmutil.ReleaseOptions{Name: "spire", Namespace: "spire-server", Revision: 1, IsUpgrade: false, IsInstall: true}
-	v, err = helmutil.ToRenderValues(chart, v, ro, helmutil.DefaultCapabilities);
+	v, err = helmutil.ToRenderValues(chart, v, ro, helmutil.DefaultCapabilities)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ spire-server:
 			Expect(err).Should(Succeed())
 			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
 			Expect(notes).Should(ContainSubstring("\"aws_kms\": {"))
-        })
+		})
 	})
 	Describe("spire-server.UpstreamAuthority.aws_pca", func() {
 		It("plugin set ok", func() {
@@ -101,6 +101,6 @@ spire-server:
 			Expect(err).Should(Succeed())
 			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
 			Expect(notes).Should(ContainSubstring("\"aws_pca\": {"))
-        })
+		})
 	})
 })

--- a/tests/unit/spire_test.go
+++ b/tests/unit/spire_test.go
@@ -87,7 +87,6 @@ spire-server:
 			notes := objs["spire/charts/spire-server/templates/configmap.yaml"]
 			Expect(notes).Should(ContainSubstring("\"aws_kms\": {"))
         })
-
 	})
 	Describe("spire-server.UpstreamAuthority.aws_pca", func() {
 		It("plugin set ok", func() {


### PR DESCRIPTION
Current configmap template renders to a wrong KeyManager and UpstreamAuthority configurarion when aws_kms and aws_pca are enabled and container is crashing. The proposed changes will fix the issue.